### PR TITLE
Design: v-componenet위한 CSS추가, v-deep 적용방식 수정

### DIFF
--- a/src/assets/base.css
+++ b/src/assets/base.css
@@ -5,8 +5,6 @@
 @custom-variant dark (&:is(.dark *));
 
 @import 'tailwindcss';
-
-
 @theme {
   --color-*: initial;
   --color-main-600: #b83700;
@@ -80,7 +78,6 @@
   --sidebar-border: oklch(0.923 0.003 48.717);
   --sidebar-ring: oklch(0.869 0.005 56.366);
 }
-
 .dark {
   --background: oklch(0.147 0.004 49.25);
   --foreground: oklch(0.985 0.001 106.423);
@@ -162,4 +159,4117 @@
   body {
     @apply bg-background text-foreground;
   }
+}
+
+:root {
+  --v-theme-overlay-multiplier: 0;
+  --v-scrollbar-offset: 0px;
+}
+
+/* vuetify components를 위한 코드. 오버라이딩 문제 발생하면 해당 line만 지우시면 됩니다. */
+
+
+.dialog-transition-enter-active,
+.dialog-bottom-transition-enter-active,
+.dialog-top-transition-enter-active {
+  transition-duration: 225ms !important;
+  transition-timing-function: cubic-bezier(0, 0, 0.2, 1) !important;
+}
+.dialog-transition-leave-active,
+.dialog-bottom-transition-leave-active,
+.dialog-top-transition-leave-active {
+  transition-duration: 125ms !important;
+  transition-timing-function: cubic-bezier(0.4, 0, 1, 1) !important;
+}
+.dialog-transition-enter-active, .dialog-transition-leave-active,
+.dialog-bottom-transition-enter-active,
+.dialog-bottom-transition-leave-active,
+.dialog-top-transition-enter-active,
+.dialog-top-transition-leave-active {
+  transition-property: transform, opacity !important;
+  pointer-events: none;
+}
+
+.dialog-transition-enter-from, .dialog-transition-leave-to {
+  transform: scale(0.9);
+  opacity: 0;
+}
+.dialog-transition-enter-to, .dialog-transition-leave-from {
+  opacity: 1;
+}
+
+.dialog-bottom-transition-enter-from, .dialog-bottom-transition-leave-to {
+  transform: translateY(calc(50vh + 50%));
+}
+
+.dialog-top-transition-enter-from, .dialog-top-transition-leave-to {
+  transform: translateY(calc(-50vh - 50%));
+}
+
+.picker-transition-enter-active,
+.picker-reverse-transition-enter-active {
+  transition-duration: 0.3s !important;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1) !important;
+}
+.picker-transition-leave-active,
+.picker-reverse-transition-leave-active {
+  transition-duration: 0.3s !important;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1) !important;
+}
+.picker-transition-move,
+.picker-reverse-transition-move {
+  transition-duration: 0.5s !important;
+  transition-property: transform !important;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1) !important;
+}
+.picker-transition-enter-from, .picker-transition-leave-to,
+.picker-reverse-transition-enter-from,
+.picker-reverse-transition-leave-to {
+  opacity: 0;
+}
+.picker-transition-leave-from, .picker-transition-leave-active, .picker-transition-leave-to,
+.picker-reverse-transition-leave-from,
+.picker-reverse-transition-leave-active,
+.picker-reverse-transition-leave-to {
+  position: absolute !important;
+}
+.picker-transition-enter-active, .picker-transition-leave-active,
+.picker-reverse-transition-enter-active,
+.picker-reverse-transition-leave-active {
+  transition-property: transform, opacity !important;
+}
+
+.picker-transition-enter-active {
+  transition-duration: 0.3s !important;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1) !important;
+}
+.picker-transition-leave-active {
+  transition-duration: 0.3s !important;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1) !important;
+}
+.picker-transition-move {
+  transition-duration: 0.5s !important;
+  transition-property: transform !important;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1) !important;
+}
+.picker-transition-enter-from {
+  transform: translate(100%, 0);
+}
+.picker-transition-leave-to {
+  transform: translate(-100%, 0);
+}
+
+.picker-reverse-transition-enter-active {
+  transition-duration: 0.3s !important;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1) !important;
+}
+.picker-reverse-transition-leave-active {
+  transition-duration: 0.3s !important;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1) !important;
+}
+.picker-reverse-transition-move {
+  transition-duration: 0.5s !important;
+  transition-property: transform !important;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1) !important;
+}
+.picker-reverse-transition-enter-from {
+  transform: translate(-100%, 0);
+}
+.picker-reverse-transition-leave-to {
+  transform: translate(100%, 0);
+}
+
+.expand-transition-enter-active {
+  transition-duration: 0.3s !important;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1) !important;
+}
+.expand-transition-leave-active {
+  transition-duration: 0.3s !important;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1) !important;
+}
+.expand-transition-move {
+  transition-duration: 0.5s !important;
+  transition-property: transform !important;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1) !important;
+}
+.expand-transition-enter-active, .expand-transition-leave-active {
+  transition-property: height !important;
+}
+
+.expand-x-transition-enter-active {
+  transition-duration: 0.3s !important;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1) !important;
+}
+.expand-x-transition-leave-active {
+  transition-duration: 0.3s !important;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1) !important;
+}
+.expand-x-transition-move {
+  transition-duration: 0.5s !important;
+  transition-property: transform !important;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1) !important;
+}
+.expand-x-transition-enter-active, .expand-x-transition-leave-active {
+  transition-property: width !important;
+}
+
+.scale-transition-enter-active {
+  transition-duration: 0.3s !important;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1) !important;
+}
+.scale-transition-leave-active {
+  transition-duration: 0.3s !important;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1) !important;
+}
+.scale-transition-move {
+  transition-duration: 0.5s !important;
+  transition-property: transform !important;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1) !important;
+}
+.scale-transition-leave-to {
+  opacity: 0;
+}
+.scale-transition-leave-active {
+  transition-duration: 100ms !important;
+}
+.scale-transition-enter-from {
+  opacity: 0;
+  transform: scale(0);
+}
+.scale-transition-enter-active, .scale-transition-leave-active {
+  transition-property: transform, opacity !important;
+}
+
+.scale-rotate-transition-enter-active {
+  transition-duration: 0.3s !important;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1) !important;
+}
+.scale-rotate-transition-leave-active {
+  transition-duration: 0.3s !important;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1) !important;
+}
+.scale-rotate-transition-move {
+  transition-duration: 0.5s !important;
+  transition-property: transform !important;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1) !important;
+}
+.scale-rotate-transition-leave-to {
+  opacity: 0;
+}
+.scale-rotate-transition-leave-active {
+  transition-duration: 100ms !important;
+}
+.scale-rotate-transition-enter-from {
+  opacity: 0;
+  transform: scale(0) rotate(-45deg);
+}
+.scale-rotate-transition-enter-active, .scale-rotate-transition-leave-active {
+  transition-property: transform, opacity !important;
+}
+
+.scale-rotate-reverse-transition-enter-active {
+  transition-duration: 0.3s !important;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1) !important;
+}
+.scale-rotate-reverse-transition-leave-active {
+  transition-duration: 0.3s !important;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1) !important;
+}
+.scale-rotate-reverse-transition-move {
+  transition-duration: 0.5s !important;
+  transition-property: transform !important;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1) !important;
+}
+.scale-rotate-reverse-transition-leave-to {
+  opacity: 0;
+}
+.scale-rotate-reverse-transition-leave-active {
+  transition-duration: 100ms !important;
+}
+.scale-rotate-reverse-transition-enter-from {
+  opacity: 0;
+  transform: scale(0) rotate(45deg);
+}
+.scale-rotate-reverse-transition-enter-active, .scale-rotate-reverse-transition-leave-active {
+  transition-property: transform, opacity !important;
+}
+
+.message-transition-enter-active {
+  transition-duration: 0.3s !important;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1) !important;
+}
+.message-transition-leave-active {
+  transition-duration: 0.3s !important;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1) !important;
+}
+.message-transition-move {
+  transition-duration: 0.5s !important;
+  transition-property: transform !important;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1) !important;
+}
+.message-transition-enter-from, .message-transition-leave-to {
+  opacity: 0;
+  transform: translateY(-15px);
+}
+.message-transition-leave-from, .message-transition-leave-active {
+  position: absolute;
+}
+.message-transition-enter-active, .message-transition-leave-active {
+  transition-property: transform, opacity !important;
+}
+
+.slide-y-transition-enter-active {
+  transition-duration: 0.3s !important;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1) !important;
+}
+.slide-y-transition-leave-active {
+  transition-duration: 0.3s !important;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1) !important;
+}
+.slide-y-transition-move {
+  transition-duration: 0.5s !important;
+  transition-property: transform !important;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1) !important;
+}
+.slide-y-transition-enter-from, .slide-y-transition-leave-to {
+  opacity: 0;
+  transform: translateY(-15px);
+}
+.slide-y-transition-enter-active, .slide-y-transition-leave-active {
+  transition-property: transform, opacity !important;
+}
+
+.slide-y-reverse-transition-enter-active {
+  transition-duration: 0.3s !important;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1) !important;
+}
+.slide-y-reverse-transition-leave-active {
+  transition-duration: 0.3s !important;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1) !important;
+}
+.slide-y-reverse-transition-move {
+  transition-duration: 0.5s !important;
+  transition-property: transform !important;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1) !important;
+}
+.slide-y-reverse-transition-enter-from, .slide-y-reverse-transition-leave-to {
+  opacity: 0;
+  transform: translateY(15px);
+}
+.slide-y-reverse-transition-enter-active, .slide-y-reverse-transition-leave-active {
+  transition-property: transform, opacity !important;
+}
+
+.scroll-y-transition-enter-active {
+  transition-duration: 0.3s !important;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1) !important;
+}
+.scroll-y-transition-leave-active {
+  transition-duration: 0.3s !important;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1) !important;
+}
+.scroll-y-transition-move {
+  transition-duration: 0.5s !important;
+  transition-property: transform !important;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1) !important;
+}
+.scroll-y-transition-enter-from, .scroll-y-transition-leave-to {
+  opacity: 0;
+}
+.scroll-y-transition-enter-from {
+  transform: translateY(-15px);
+}
+.scroll-y-transition-leave-to {
+  transform: translateY(15px);
+}
+.scroll-y-transition-enter-active, .scroll-y-transition-leave-active {
+  transition-property: transform, opacity !important;
+}
+
+.scroll-y-reverse-transition-enter-active {
+  transition-duration: 0.3s !important;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1) !important;
+}
+.scroll-y-reverse-transition-leave-active {
+  transition-duration: 0.3s !important;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1) !important;
+}
+.scroll-y-reverse-transition-move {
+  transition-duration: 0.5s !important;
+  transition-property: transform !important;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1) !important;
+}
+.scroll-y-reverse-transition-enter-from, .scroll-y-reverse-transition-leave-to {
+  opacity: 0;
+}
+.scroll-y-reverse-transition-enter-from {
+  transform: translateY(15px);
+}
+.scroll-y-reverse-transition-leave-to {
+  transform: translateY(-15px);
+}
+.scroll-y-reverse-transition-enter-active, .scroll-y-reverse-transition-leave-active {
+  transition-property: transform, opacity !important;
+}
+
+.scroll-x-transition-enter-active {
+  transition-duration: 0.3s !important;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1) !important;
+}
+.scroll-x-transition-leave-active {
+  transition-duration: 0.3s !important;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1) !important;
+}
+.scroll-x-transition-move {
+  transition-duration: 0.5s !important;
+  transition-property: transform !important;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1) !important;
+}
+.scroll-x-transition-enter-from, .scroll-x-transition-leave-to {
+  opacity: 0;
+}
+.scroll-x-transition-enter-from {
+  transform: translateX(-15px);
+}
+.scroll-x-transition-leave-to {
+  transform: translateX(15px);
+}
+.scroll-x-transition-enter-active, .scroll-x-transition-leave-active {
+  transition-property: transform, opacity !important;
+}
+
+.scroll-x-reverse-transition-enter-active {
+  transition-duration: 0.3s !important;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1) !important;
+}
+.scroll-x-reverse-transition-leave-active {
+  transition-duration: 0.3s !important;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1) !important;
+}
+.scroll-x-reverse-transition-move {
+  transition-duration: 0.5s !important;
+  transition-property: transform !important;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1) !important;
+}
+.scroll-x-reverse-transition-enter-from, .scroll-x-reverse-transition-leave-to {
+  opacity: 0;
+}
+.scroll-x-reverse-transition-enter-from {
+  transform: translateX(15px);
+}
+.scroll-x-reverse-transition-leave-to {
+  transform: translateX(-15px);
+}
+.scroll-x-reverse-transition-enter-active, .scroll-x-reverse-transition-leave-active {
+  transition-property: transform, opacity !important;
+}
+
+.slide-x-transition-enter-active {
+  transition-duration: 0.3s !important;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1) !important;
+}
+.slide-x-transition-leave-active {
+  transition-duration: 0.3s !important;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1) !important;
+}
+.slide-x-transition-move {
+  transition-duration: 0.5s !important;
+  transition-property: transform !important;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1) !important;
+}
+.slide-x-transition-enter-from, .slide-x-transition-leave-to {
+  opacity: 0;
+  transform: translateX(-15px);
+}
+.slide-x-transition-enter-active, .slide-x-transition-leave-active {
+  transition-property: transform, opacity !important;
+}
+
+.slide-x-reverse-transition-enter-active {
+  transition-duration: 0.3s !important;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1) !important;
+}
+.slide-x-reverse-transition-leave-active {
+  transition-duration: 0.3s !important;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1) !important;
+}
+.slide-x-reverse-transition-move {
+  transition-duration: 0.5s !important;
+  transition-property: transform !important;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1) !important;
+}
+.slide-x-reverse-transition-enter-from, .slide-x-reverse-transition-leave-to {
+  opacity: 0;
+  transform: translateX(15px);
+}
+.slide-x-reverse-transition-enter-active, .slide-x-reverse-transition-leave-active {
+  transition-property: transform, opacity !important;
+}
+
+.fade-transition-enter-active {
+  transition-duration: 0.3s !important;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1) !important;
+}
+.fade-transition-leave-active {
+  transition-duration: 0.3s !important;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1) !important;
+}
+.fade-transition-move {
+  transition-duration: 0.5s !important;
+  transition-property: transform !important;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1) !important;
+}
+.fade-transition-enter-from, .fade-transition-leave-to {
+  opacity: 0 !important;
+}
+.fade-transition-enter-active, .fade-transition-leave-active {
+  transition-property: opacity !important;
+}
+
+.fab-transition-enter-active {
+  transition-duration: 0.3s !important;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1) !important;
+}
+.fab-transition-leave-active {
+  transition-duration: 0.3s !important;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1) !important;
+}
+.fab-transition-move {
+  transition-duration: 0.5s !important;
+  transition-property: transform !important;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1) !important;
+}
+.fab-transition-enter-from, .fab-transition-leave-to {
+  transform: scale(0) rotate(-45deg);
+}
+.fab-transition-enter-active, .fab-transition-leave-active {
+  transition-property: transform !important;
+}
+
+.v-locale--is-rtl {
+  direction: rtl;
+}
+.v-locale--is-ltr {
+  direction: ltr;
+}
+
+html.overflow-y-hidden {
+  overflow-y: hidden !important;
+}
+
+.elevation-24 {
+  box-shadow: 0px 11px 15px -7px var(--v-shadow-key-umbra-opacity, rgba(0, 0, 0, 0.2)), 0px 24px 38px 3px var(--v-shadow-key-penumbra-opacity, rgba(0, 0, 0, 0.14)), 0px 9px 46px 8px var(--v-shadow-key-ambient-opacity, rgba(0, 0, 0, 0.12)) !important;
+}
+
+.elevation-23 {
+  box-shadow: 0px 11px 14px -7px var(--v-shadow-key-umbra-opacity, rgba(0, 0, 0, 0.2)), 0px 23px 36px 3px var(--v-shadow-key-penumbra-opacity, rgba(0, 0, 0, 0.14)), 0px 9px 44px 8px var(--v-shadow-key-ambient-opacity, rgba(0, 0, 0, 0.12)) !important;
+}
+
+.elevation-22 {
+  box-shadow: 0px 10px 14px -6px var(--v-shadow-key-umbra-opacity, rgba(0, 0, 0, 0.2)), 0px 22px 35px 3px var(--v-shadow-key-penumbra-opacity, rgba(0, 0, 0, 0.14)), 0px 8px 42px 7px var(--v-shadow-key-ambient-opacity, rgba(0, 0, 0, 0.12)) !important;
+}
+
+.elevation-21 {
+  box-shadow: 0px 10px 13px -6px var(--v-shadow-key-umbra-opacity, rgba(0, 0, 0, 0.2)), 0px 21px 33px 3px var(--v-shadow-key-penumbra-opacity, rgba(0, 0, 0, 0.14)), 0px 8px 40px 7px var(--v-shadow-key-ambient-opacity, rgba(0, 0, 0, 0.12)) !important;
+}
+
+.elevation-20 {
+  box-shadow: 0px 10px 13px -6px var(--v-shadow-key-umbra-opacity, rgba(0, 0, 0, 0.2)), 0px 20px 31px 3px var(--v-shadow-key-penumbra-opacity, rgba(0, 0, 0, 0.14)), 0px 8px 38px 7px var(--v-shadow-key-ambient-opacity, rgba(0, 0, 0, 0.12)) !important;
+}
+
+.elevation-19 {
+  box-shadow: 0px 9px 12px -6px var(--v-shadow-key-umbra-opacity, rgba(0, 0, 0, 0.2)), 0px 19px 29px 2px var(--v-shadow-key-penumbra-opacity, rgba(0, 0, 0, 0.14)), 0px 7px 36px 6px var(--v-shadow-key-ambient-opacity, rgba(0, 0, 0, 0.12)) !important;
+}
+
+.elevation-18 {
+  box-shadow: 0px 9px 11px -5px var(--v-shadow-key-umbra-opacity, rgba(0, 0, 0, 0.2)), 0px 18px 28px 2px var(--v-shadow-key-penumbra-opacity, rgba(0, 0, 0, 0.14)), 0px 7px 34px 6px var(--v-shadow-key-ambient-opacity, rgba(0, 0, 0, 0.12)) !important;
+}
+
+.elevation-17 {
+  box-shadow: 0px 8px 11px -5px var(--v-shadow-key-umbra-opacity, rgba(0, 0, 0, 0.2)), 0px 17px 26px 2px var(--v-shadow-key-penumbra-opacity, rgba(0, 0, 0, 0.14)), 0px 6px 32px 5px var(--v-shadow-key-ambient-opacity, rgba(0, 0, 0, 0.12)) !important;
+}
+
+.elevation-16 {
+  box-shadow: 0px 8px 10px -5px var(--v-shadow-key-umbra-opacity, rgba(0, 0, 0, 0.2)), 0px 16px 24px 2px var(--v-shadow-key-penumbra-opacity, rgba(0, 0, 0, 0.14)), 0px 6px 30px 5px var(--v-shadow-key-ambient-opacity, rgba(0, 0, 0, 0.12)) !important;
+}
+
+.elevation-15 {
+  box-shadow: 0px 8px 9px -5px var(--v-shadow-key-umbra-opacity, rgba(0, 0, 0, 0.2)), 0px 15px 22px 2px var(--v-shadow-key-penumbra-opacity, rgba(0, 0, 0, 0.14)), 0px 6px 28px 5px var(--v-shadow-key-ambient-opacity, rgba(0, 0, 0, 0.12)) !important;
+}
+
+.elevation-14 {
+  box-shadow: 0px 7px 9px -4px var(--v-shadow-key-umbra-opacity, rgba(0, 0, 0, 0.2)), 0px 14px 21px 2px var(--v-shadow-key-penumbra-opacity, rgba(0, 0, 0, 0.14)), 0px 5px 26px 4px var(--v-shadow-key-ambient-opacity, rgba(0, 0, 0, 0.12)) !important;
+}
+
+.elevation-13 {
+  box-shadow: 0px 7px 8px -4px var(--v-shadow-key-umbra-opacity, rgba(0, 0, 0, 0.2)), 0px 13px 19px 2px var(--v-shadow-key-penumbra-opacity, rgba(0, 0, 0, 0.14)), 0px 5px 24px 4px var(--v-shadow-key-ambient-opacity, rgba(0, 0, 0, 0.12)) !important;
+}
+
+.elevation-12 {
+  box-shadow: 0px 7px 8px -4px var(--v-shadow-key-umbra-opacity, rgba(0, 0, 0, 0.2)), 0px 12px 17px 2px var(--v-shadow-key-penumbra-opacity, rgba(0, 0, 0, 0.14)), 0px 5px 22px 4px var(--v-shadow-key-ambient-opacity, rgba(0, 0, 0, 0.12)) !important;
+}
+
+.elevation-11 {
+  box-shadow: 0px 6px 7px -4px var(--v-shadow-key-umbra-opacity, rgba(0, 0, 0, 0.2)), 0px 11px 15px 1px var(--v-shadow-key-penumbra-opacity, rgba(0, 0, 0, 0.14)), 0px 4px 20px 3px var(--v-shadow-key-ambient-opacity, rgba(0, 0, 0, 0.12)) !important;
+}
+
+.elevation-10 {
+  box-shadow: 0px 6px 6px -3px var(--v-shadow-key-umbra-opacity, rgba(0, 0, 0, 0.2)), 0px 10px 14px 1px var(--v-shadow-key-penumbra-opacity, rgba(0, 0, 0, 0.14)), 0px 4px 18px 3px var(--v-shadow-key-ambient-opacity, rgba(0, 0, 0, 0.12)) !important;
+}
+
+.elevation-9 {
+  box-shadow: 0px 5px 6px -3px var(--v-shadow-key-umbra-opacity, rgba(0, 0, 0, 0.2)), 0px 9px 12px 1px var(--v-shadow-key-penumbra-opacity, rgba(0, 0, 0, 0.14)), 0px 3px 16px 2px var(--v-shadow-key-ambient-opacity, rgba(0, 0, 0, 0.12)) !important;
+}
+
+.elevation-8 {
+  box-shadow: 0px 5px 5px -3px var(--v-shadow-key-umbra-opacity, rgba(0, 0, 0, 0.2)), 0px 8px 10px 1px var(--v-shadow-key-penumbra-opacity, rgba(0, 0, 0, 0.14)), 0px 3px 14px 2px var(--v-shadow-key-ambient-opacity, rgba(0, 0, 0, 0.12)) !important;
+}
+
+.elevation-7 {
+  box-shadow: 0px 4px 5px -2px var(--v-shadow-key-umbra-opacity, rgba(0, 0, 0, 0.2)), 0px 7px 10px 1px var(--v-shadow-key-penumbra-opacity, rgba(0, 0, 0, 0.14)), 0px 2px 16px 1px var(--v-shadow-key-ambient-opacity, rgba(0, 0, 0, 0.12)) !important;
+}
+
+.elevation-6 {
+  box-shadow: 0px 3px 5px -1px var(--v-shadow-key-umbra-opacity, rgba(0, 0, 0, 0.2)), 0px 6px 10px 0px var(--v-shadow-key-penumbra-opacity, rgba(0, 0, 0, 0.14)), 0px 1px 18px 0px var(--v-shadow-key-ambient-opacity, rgba(0, 0, 0, 0.12)) !important;
+}
+
+.elevation-5 {
+  box-shadow: 0px 3px 5px -1px var(--v-shadow-key-umbra-opacity, rgba(0, 0, 0, 0.2)), 0px 5px 8px 0px var(--v-shadow-key-penumbra-opacity, rgba(0, 0, 0, 0.14)), 0px 1px 14px 0px var(--v-shadow-key-ambient-opacity, rgba(0, 0, 0, 0.12)) !important;
+}
+
+.elevation-4 {
+  box-shadow: 0px 2px 4px -1px var(--v-shadow-key-umbra-opacity, rgba(0, 0, 0, 0.2)), 0px 4px 5px 0px var(--v-shadow-key-penumbra-opacity, rgba(0, 0, 0, 0.14)), 0px 1px 10px 0px var(--v-shadow-key-ambient-opacity, rgba(0, 0, 0, 0.12)) !important;
+}
+
+.elevation-3 {
+  box-shadow: 0px 3px 3px -2px var(--v-shadow-key-umbra-opacity, rgba(0, 0, 0, 0.2)), 0px 3px 4px 0px var(--v-shadow-key-penumbra-opacity, rgba(0, 0, 0, 0.14)), 0px 1px 8px 0px var(--v-shadow-key-ambient-opacity, rgba(0, 0, 0, 0.12)) !important;
+}
+
+.elevation-2 {
+  box-shadow: 0px 3px 1px -2px var(--v-shadow-key-umbra-opacity, rgba(0, 0, 0, 0.2)), 0px 2px 2px 0px var(--v-shadow-key-penumbra-opacity, rgba(0, 0, 0, 0.14)), 0px 1px 5px 0px var(--v-shadow-key-ambient-opacity, rgba(0, 0, 0, 0.12)) !important;
+}
+
+.elevation-1 {
+  box-shadow: 0px 2px 1px -1px var(--v-shadow-key-umbra-opacity, rgba(0, 0, 0, 0.2)), 0px 1px 1px 0px var(--v-shadow-key-penumbra-opacity, rgba(0, 0, 0, 0.14)), 0px 1px 3px 0px var(--v-shadow-key-ambient-opacity, rgba(0, 0, 0, 0.12)) !important;
+}
+
+.elevation-0 {
+  box-shadow: 0px 0px 0px 0px var(--v-shadow-key-umbra-opacity, rgba(0, 0, 0, 0.2)), 0px 0px 0px 0px var(--v-shadow-key-penumbra-opacity, rgba(0, 0, 0, 0.14)), 0px 0px 0px 0px var(--v-shadow-key-ambient-opacity, rgba(0, 0, 0, 0.12)) !important;
+}
+
+.d-sr-only,
+.d-sr-only-focusable:not(:focus) {
+  border: 0 !important;
+  clip: rect(0, 0, 0, 0) !important;
+  height: 1px !important;
+  margin: -1px !important;
+  overflow: hidden !important;
+  padding: 0 !important;
+  position: absolute !important;
+  white-space: nowrap !important;
+  width: 1px !important;
+}
+
+.overflow-auto {
+  overflow: auto !important;
+}
+
+.overflow-hidden {
+  overflow: hidden !important;
+}
+
+.overflow-visible {
+  overflow: visible !important;
+}
+
+.overflow-scroll {
+  overflow: scroll !important;
+}
+
+.overflow-x-auto {
+  overflow-x: auto !important;
+}
+
+.overflow-x-hidden {
+  overflow-x: hidden !important;
+}
+
+.overflow-x-scroll {
+  overflow-x: scroll !important;
+}
+
+.overflow-y-auto {
+  overflow-y: auto !important;
+}
+
+.overflow-y-hidden {
+  overflow-y: hidden !important;
+}
+
+.overflow-y-scroll {
+  overflow-y: scroll !important;
+}
+
+.d-none {
+  display: none !important;
+}
+
+.d-inline {
+  display: inline !important;
+}
+
+.d-inline-block {
+  display: inline-block !important;
+}
+
+.d-block {
+  display: block !important;
+}
+
+.d-table {
+  display: table !important;
+}
+
+.d-table-row {
+  display: table-row !important;
+}
+
+.d-table-cell {
+  display: table-cell !important;
+}
+
+.d-flex {
+  display: flex !important;
+}
+
+.d-inline-flex {
+  display: inline-flex !important;
+}
+
+.float-none {
+  float: none !important;
+}
+
+.float-left {
+  float: left !important;
+}
+
+.float-right {
+  float: right !important;
+}
+
+.v-locale--is-rtl .float-end {
+  float: left !important;
+}
+
+.v-locale--is-rtl .float-start {
+  float: right !important;
+}
+
+.v-locale--is-ltr .float-end {
+  float: right !important;
+}
+
+.v-locale--is-ltr .float-start {
+  float: left !important;
+}
+
+.order-first {
+  order: -1 !important;
+}
+
+.order-0 {
+  order: 0 !important;
+}
+
+.order-1 {
+  order: 1 !important;
+}
+
+.order-2 {
+  order: 2 !important;
+}
+
+.order-3 {
+  order: 3 !important;
+}
+
+.order-4 {
+  order: 4 !important;
+}
+
+.order-5 {
+  order: 5 !important;
+}
+
+.order-6 {
+  order: 6 !important;
+}
+
+.order-7 {
+  order: 7 !important;
+}
+
+.order-8 {
+  order: 8 !important;
+}
+
+.order-9 {
+  order: 9 !important;
+}
+
+.order-10 {
+  order: 10 !important;
+}
+
+.order-11 {
+  order: 11 !important;
+}
+
+.order-12 {
+  order: 12 !important;
+}
+
+.order-last {
+  order: 13 !important;
+}
+
+.ga-0 {
+  gap: 0px !important;
+}
+
+.ga-1 {
+  gap: 4px !important;
+}
+
+.ga-2 {
+  gap: 8px !important;
+}
+
+.ga-3 {
+  gap: 12px !important;
+}
+
+.ga-4 {
+  gap: 16px !important;
+}
+
+.ga-5 {
+  gap: 20px !important;
+}
+
+.ga-6 {
+  gap: 24px !important;
+}
+
+.ga-7 {
+  gap: 28px !important;
+}
+
+.ga-8 {
+  gap: 32px !important;
+}
+
+.ga-9 {
+  gap: 36px !important;
+}
+
+.ga-10 {
+  gap: 40px !important;
+}
+
+.ga-11 {
+  gap: 44px !important;
+}
+
+.ga-12 {
+  gap: 48px !important;
+}
+
+.ga-13 {
+  gap: 52px !important;
+}
+
+.ga-14 {
+  gap: 56px !important;
+}
+
+.ga-15 {
+  gap: 60px !important;
+}
+
+.ga-16 {
+  gap: 64px !important;
+}
+
+.ga-auto {
+  gap: auto !important;
+}
+
+.gr-0 {
+  row-gap: 0px !important;
+}
+
+.gr-1 {
+  row-gap: 4px !important;
+}
+
+.gr-2 {
+  row-gap: 8px !important;
+}
+
+.gr-3 {
+  row-gap: 12px !important;
+}
+
+.gr-4 {
+  row-gap: 16px !important;
+}
+
+.gr-5 {
+  row-gap: 20px !important;
+}
+
+.gr-6 {
+  row-gap: 24px !important;
+}
+
+.gr-7 {
+  row-gap: 28px !important;
+}
+
+.gr-8 {
+  row-gap: 32px !important;
+}
+
+.gr-9 {
+  row-gap: 36px !important;
+}
+
+.gr-10 {
+  row-gap: 40px !important;
+}
+
+.gr-11 {
+  row-gap: 44px !important;
+}
+
+.gr-12 {
+  row-gap: 48px !important;
+}
+
+.gr-13 {
+  row-gap: 52px !important;
+}
+
+.gr-14 {
+  row-gap: 56px !important;
+}
+
+.gr-15 {
+  row-gap: 60px !important;
+}
+
+.gr-16 {
+  row-gap: 64px !important;
+}
+
+.gr-auto {
+  row-gap: auto !important;
+}
+
+.gc-0 {
+  column-gap: 0px !important;
+}
+
+.gc-1 {
+  column-gap: 4px !important;
+}
+
+.gc-2 {
+  column-gap: 8px !important;
+}
+
+.gc-3 {
+  column-gap: 12px !important;
+}
+
+.gc-4 {
+  column-gap: 16px !important;
+}
+
+.gc-5 {
+  column-gap: 20px !important;
+}
+
+.gc-6 {
+  column-gap: 24px !important;
+}
+
+.gc-7 {
+  column-gap: 28px !important;
+}
+
+.gc-8 {
+  column-gap: 32px !important;
+}
+
+.gc-9 {
+  column-gap: 36px !important;
+}
+
+.gc-10 {
+  column-gap: 40px !important;
+}
+
+.gc-11 {
+  column-gap: 44px !important;
+}
+
+.gc-12 {
+  column-gap: 48px !important;
+}
+
+.gc-13 {
+  column-gap: 52px !important;
+}
+
+.gc-14 {
+  column-gap: 56px !important;
+}
+
+.gc-15 {
+  column-gap: 60px !important;
+}
+
+.gc-16 {
+  column-gap: 64px !important;
+}
+
+.gc-auto {
+  column-gap: auto !important;
+}
+
+.ma-0 {
+  margin: 0px !important;
+}
+
+.ma-1 {
+  margin: 4px !important;
+}
+
+.ma-2 {
+  margin: 8px !important;
+}
+
+.ma-3 {
+  margin: 12px !important;
+}
+
+.ma-4 {
+  margin: 16px !important;
+}
+
+.ma-5 {
+  margin: 20px !important;
+}
+
+.ma-6 {
+  margin: 24px !important;
+}
+
+.ma-7 {
+  margin: 28px !important;
+}
+
+.ma-8 {
+  margin: 32px !important;
+}
+
+.ma-9 {
+  margin: 36px !important;
+}
+
+.ma-10 {
+  margin: 40px !important;
+}
+
+.ma-11 {
+  margin: 44px !important;
+}
+
+.ma-12 {
+  margin: 48px !important;
+}
+
+.ma-13 {
+  margin: 52px !important;
+}
+
+.ma-14 {
+  margin: 56px !important;
+}
+
+.ma-15 {
+  margin: 60px !important;
+}
+
+.ma-16 {
+  margin: 64px !important;
+}
+
+.ma-auto {
+  margin: auto !important;
+}
+
+.mx-0 {
+  margin-right: 0px !important;
+  margin-left: 0px !important;
+}
+
+.mx-1 {
+  margin-right: 4px !important;
+  margin-left: 4px !important;
+}
+
+.mx-2 {
+  margin-right: 8px !important;
+  margin-left: 8px !important;
+}
+
+.mx-3 {
+  margin-right: 12px !important;
+  margin-left: 12px !important;
+}
+
+.mx-4 {
+  margin-right: 16px !important;
+  margin-left: 16px !important;
+}
+
+.mx-5 {
+  margin-right: 20px !important;
+  margin-left: 20px !important;
+}
+
+.mx-6 {
+  margin-right: 24px !important;
+  margin-left: 24px !important;
+}
+
+.mx-7 {
+  margin-right: 28px !important;
+  margin-left: 28px !important;
+}
+
+.mx-8 {
+  margin-right: 32px !important;
+  margin-left: 32px !important;
+}
+
+.mx-9 {
+  margin-right: 36px !important;
+  margin-left: 36px !important;
+}
+
+.mx-10 {
+  margin-right: 40px !important;
+  margin-left: 40px !important;
+}
+
+.mx-11 {
+  margin-right: 44px !important;
+  margin-left: 44px !important;
+}
+
+.mx-12 {
+  margin-right: 48px !important;
+  margin-left: 48px !important;
+}
+
+.mx-13 {
+  margin-right: 52px !important;
+  margin-left: 52px !important;
+}
+
+.mx-14 {
+  margin-right: 56px !important;
+  margin-left: 56px !important;
+}
+
+.mx-15 {
+  margin-right: 60px !important;
+  margin-left: 60px !important;
+}
+
+.mx-16 {
+  margin-right: 64px !important;
+  margin-left: 64px !important;
+}
+
+.mx-auto {
+  margin-right: auto !important;
+  margin-left: auto !important;
+}
+
+.my-0 {
+  margin-top: 0px !important;
+  margin-bottom: 0px !important;
+}
+
+.my-1 {
+  margin-top: 4px !important;
+  margin-bottom: 4px !important;
+}
+
+.my-2 {
+  margin-top: 8px !important;
+  margin-bottom: 8px !important;
+}
+
+.my-3 {
+  margin-top: 12px !important;
+  margin-bottom: 12px !important;
+}
+
+.my-4 {
+  margin-top: 16px !important;
+  margin-bottom: 16px !important;
+}
+
+.my-5 {
+  margin-top: 20px !important;
+  margin-bottom: 20px !important;
+}
+
+.my-6 {
+  margin-top: 24px !important;
+  margin-bottom: 24px !important;
+}
+
+.my-7 {
+  margin-top: 28px !important;
+  margin-bottom: 28px !important;
+}
+
+.my-8 {
+  margin-top: 32px !important;
+  margin-bottom: 32px !important;
+}
+
+.my-9 {
+  margin-top: 36px !important;
+  margin-bottom: 36px !important;
+}
+
+.my-10 {
+  margin-top: 40px !important;
+  margin-bottom: 40px !important;
+}
+
+.my-11 {
+  margin-top: 44px !important;
+  margin-bottom: 44px !important;
+}
+
+.my-12 {
+  margin-top: 48px !important;
+  margin-bottom: 48px !important;
+}
+
+.my-13 {
+  margin-top: 52px !important;
+  margin-bottom: 52px !important;
+}
+
+.my-14 {
+  margin-top: 56px !important;
+  margin-bottom: 56px !important;
+}
+
+.my-15 {
+  margin-top: 60px !important;
+  margin-bottom: 60px !important;
+}
+
+.my-16 {
+  margin-top: 64px !important;
+  margin-bottom: 64px !important;
+}
+
+.my-auto {
+  margin-top: auto !important;
+  margin-bottom: auto !important;
+}
+
+.mt-0 {
+  margin-top: 0px !important;
+}
+
+.mt-1 {
+  margin-top: 4px !important;
+}
+
+.mt-2 {
+  margin-top: 8px !important;
+}
+
+.mt-3 {
+  margin-top: 12px !important;
+}
+
+.mt-4 {
+  margin-top: 16px !important;
+}
+
+.mt-5 {
+  margin-top: 20px !important;
+}
+
+.mt-6 {
+  margin-top: 24px !important;
+}
+
+.mt-7 {
+  margin-top: 28px !important;
+}
+
+.mt-8 {
+  margin-top: 32px !important;
+}
+
+.mt-9 {
+  margin-top: 36px !important;
+}
+
+.mt-10 {
+  margin-top: 40px !important;
+}
+
+.mt-11 {
+  margin-top: 44px !important;
+}
+
+.mt-12 {
+  margin-top: 48px !important;
+}
+
+.mt-13 {
+  margin-top: 52px !important;
+}
+
+.mt-14 {
+  margin-top: 56px !important;
+}
+
+.mt-15 {
+  margin-top: 60px !important;
+}
+
+.mt-16 {
+  margin-top: 64px !important;
+}
+
+.mt-auto {
+  margin-top: auto !important;
+}
+
+.mr-0 {
+  margin-right: 0px !important;
+}
+
+.mr-1 {
+  margin-right: 4px !important;
+}
+
+.mr-2 {
+  margin-right: 8px !important;
+}
+
+.mr-3 {
+  margin-right: 12px !important;
+}
+
+.mr-4 {
+  margin-right: 16px !important;
+}
+
+.mr-5 {
+  margin-right: 20px !important;
+}
+
+.mr-6 {
+  margin-right: 24px !important;
+}
+
+.mr-7 {
+  margin-right: 28px !important;
+}
+
+.mr-8 {
+  margin-right: 32px !important;
+}
+
+.mr-9 {
+  margin-right: 36px !important;
+}
+
+.mr-10 {
+  margin-right: 40px !important;
+}
+
+.mr-11 {
+  margin-right: 44px !important;
+}
+
+.mr-12 {
+  margin-right: 48px !important;
+}
+
+.mr-13 {
+  margin-right: 52px !important;
+}
+
+.mr-14 {
+  margin-right: 56px !important;
+}
+
+.mr-15 {
+  margin-right: 60px !important;
+}
+
+.mr-16 {
+  margin-right: 64px !important;
+}
+
+.mr-auto {
+  margin-right: auto !important;
+}
+
+.mb-0 {
+  margin-bottom: 0px !important;
+}
+
+.mb-1 {
+  margin-bottom: 4px !important;
+}
+
+.mb-2 {
+  margin-bottom: 8px !important;
+}
+
+.mb-3 {
+  margin-bottom: 12px !important;
+}
+
+.mb-4 {
+  margin-bottom: 16px !important;
+}
+
+.mb-5 {
+  margin-bottom: 20px !important;
+}
+
+.mb-6 {
+  margin-bottom: 24px !important;
+}
+
+.mb-7 {
+  margin-bottom: 28px !important;
+}
+
+.mb-8 {
+  margin-bottom: 32px !important;
+}
+
+.mb-9 {
+  margin-bottom: 36px !important;
+}
+
+.mb-10 {
+  margin-bottom: 40px !important;
+}
+
+.mb-11 {
+  margin-bottom: 44px !important;
+}
+
+.mb-12 {
+  margin-bottom: 48px !important;
+}
+
+.mb-13 {
+  margin-bottom: 52px !important;
+}
+
+.mb-14 {
+  margin-bottom: 56px !important;
+}
+
+.mb-15 {
+  margin-bottom: 60px !important;
+}
+
+.mb-16 {
+  margin-bottom: 64px !important;
+}
+
+.mb-auto {
+  margin-bottom: auto !important;
+}
+
+.ml-0 {
+  margin-left: 0px !important;
+}
+
+.ml-1 {
+  margin-left: 4px !important;
+}
+
+.ml-2 {
+  margin-left: 8px !important;
+}
+
+.ml-3 {
+  margin-left: 12px !important;
+}
+
+.ml-4 {
+  margin-left: 16px !important;
+}
+
+.ml-5 {
+  margin-left: 20px !important;
+}
+
+.ml-6 {
+  margin-left: 24px !important;
+}
+
+.ml-7 {
+  margin-left: 28px !important;
+}
+
+.ml-8 {
+  margin-left: 32px !important;
+}
+
+.ml-9 {
+  margin-left: 36px !important;
+}
+
+.ml-10 {
+  margin-left: 40px !important;
+}
+
+.ml-11 {
+  margin-left: 44px !important;
+}
+
+.ml-12 {
+  margin-left: 48px !important;
+}
+
+.ml-13 {
+  margin-left: 52px !important;
+}
+
+.ml-14 {
+  margin-left: 56px !important;
+}
+
+.ml-15 {
+  margin-left: 60px !important;
+}
+
+.ml-16 {
+  margin-left: 64px !important;
+}
+
+.ml-auto {
+  margin-left: auto !important;
+}
+
+.ms-0 {
+  margin-inline-start: 0px !important;
+}
+
+.ms-1 {
+  margin-inline-start: 4px !important;
+}
+
+.ms-2 {
+  margin-inline-start: 8px !important;
+}
+
+.ms-3 {
+  margin-inline-start: 12px !important;
+}
+
+.ms-4 {
+  margin-inline-start: 16px !important;
+}
+
+.ms-5 {
+  margin-inline-start: 20px !important;
+}
+
+.ms-6 {
+  margin-inline-start: 24px !important;
+}
+
+.ms-7 {
+  margin-inline-start: 28px !important;
+}
+
+.ms-8 {
+  margin-inline-start: 32px !important;
+}
+
+.ms-9 {
+  margin-inline-start: 36px !important;
+}
+
+.ms-10 {
+  margin-inline-start: 40px !important;
+}
+
+.ms-11 {
+  margin-inline-start: 44px !important;
+}
+
+.ms-12 {
+  margin-inline-start: 48px !important;
+}
+
+.ms-13 {
+  margin-inline-start: 52px !important;
+}
+
+.ms-14 {
+  margin-inline-start: 56px !important;
+}
+
+.ms-15 {
+  margin-inline-start: 60px !important;
+}
+
+.ms-16 {
+  margin-inline-start: 64px !important;
+}
+
+.ms-auto {
+  margin-inline-start: auto !important;
+}
+
+.me-0 {
+  margin-inline-end: 0px !important;
+}
+
+.me-1 {
+  margin-inline-end: 4px !important;
+}
+
+.me-2 {
+  margin-inline-end: 8px !important;
+}
+
+.me-3 {
+  margin-inline-end: 12px !important;
+}
+
+.me-4 {
+  margin-inline-end: 16px !important;
+}
+
+.me-5 {
+  margin-inline-end: 20px !important;
+}
+
+.me-6 {
+  margin-inline-end: 24px !important;
+}
+
+.me-7 {
+  margin-inline-end: 28px !important;
+}
+
+.me-8 {
+  margin-inline-end: 32px !important;
+}
+
+.me-9 {
+  margin-inline-end: 36px !important;
+}
+
+.me-10 {
+  margin-inline-end: 40px !important;
+}
+
+.me-11 {
+  margin-inline-end: 44px !important;
+}
+
+.me-12 {
+  margin-inline-end: 48px !important;
+}
+
+.me-13 {
+  margin-inline-end: 52px !important;
+}
+
+.me-14 {
+  margin-inline-end: 56px !important;
+}
+
+.me-15 {
+  margin-inline-end: 60px !important;
+}
+
+.me-16 {
+  margin-inline-end: 64px !important;
+}
+
+.me-auto {
+  margin-inline-end: auto !important;
+}
+
+.ma-n1 {
+  margin: -4px !important;
+}
+
+.ma-n2 {
+  margin: -8px !important;
+}
+
+.ma-n3 {
+  margin: -12px !important;
+}
+
+.ma-n4 {
+  margin: -16px !important;
+}
+
+.ma-n5 {
+  margin: -20px !important;
+}
+
+.ma-n6 {
+  margin: -24px !important;
+}
+
+.ma-n7 {
+  margin: -28px !important;
+}
+
+.ma-n8 {
+  margin: -32px !important;
+}
+
+.ma-n9 {
+  margin: -36px !important;
+}
+
+.ma-n10 {
+  margin: -40px !important;
+}
+
+.ma-n11 {
+  margin: -44px !important;
+}
+
+.ma-n12 {
+  margin: -48px !important;
+}
+
+.ma-n13 {
+  margin: -52px !important;
+}
+
+.ma-n14 {
+  margin: -56px !important;
+}
+
+.ma-n15 {
+  margin: -60px !important;
+}
+
+.ma-n16 {
+  margin: -64px !important;
+}
+
+.mx-n1 {
+  margin-right: -4px !important;
+  margin-left: -4px !important;
+}
+
+.mx-n2 {
+  margin-right: -8px !important;
+  margin-left: -8px !important;
+}
+
+.mx-n3 {
+  margin-right: -12px !important;
+  margin-left: -12px !important;
+}
+
+.mx-n4 {
+  margin-right: -16px !important;
+  margin-left: -16px !important;
+}
+
+.mx-n5 {
+  margin-right: -20px !important;
+  margin-left: -20px !important;
+}
+
+.mx-n6 {
+  margin-right: -24px !important;
+  margin-left: -24px !important;
+}
+
+.mx-n7 {
+  margin-right: -28px !important;
+  margin-left: -28px !important;
+}
+
+.mx-n8 {
+  margin-right: -32px !important;
+  margin-left: -32px !important;
+}
+
+.mx-n9 {
+  margin-right: -36px !important;
+  margin-left: -36px !important;
+}
+
+.mx-n10 {
+  margin-right: -40px !important;
+  margin-left: -40px !important;
+}
+
+.mx-n11 {
+  margin-right: -44px !important;
+  margin-left: -44px !important;
+}
+
+.mx-n12 {
+  margin-right: -48px !important;
+  margin-left: -48px !important;
+}
+
+.mx-n13 {
+  margin-right: -52px !important;
+  margin-left: -52px !important;
+}
+
+.mx-n14 {
+  margin-right: -56px !important;
+  margin-left: -56px !important;
+}
+
+.mx-n15 {
+  margin-right: -60px !important;
+  margin-left: -60px !important;
+}
+
+.mx-n16 {
+  margin-right: -64px !important;
+  margin-left: -64px !important;
+}
+
+.my-n1 {
+  margin-top: -4px !important;
+  margin-bottom: -4px !important;
+}
+
+.my-n2 {
+  margin-top: -8px !important;
+  margin-bottom: -8px !important;
+}
+
+.my-n3 {
+  margin-top: -12px !important;
+  margin-bottom: -12px !important;
+}
+
+.my-n4 {
+  margin-top: -16px !important;
+  margin-bottom: -16px !important;
+}
+
+.my-n5 {
+  margin-top: -20px !important;
+  margin-bottom: -20px !important;
+}
+
+.my-n6 {
+  margin-top: -24px !important;
+  margin-bottom: -24px !important;
+}
+
+.my-n7 {
+  margin-top: -28px !important;
+  margin-bottom: -28px !important;
+}
+
+.my-n8 {
+  margin-top: -32px !important;
+  margin-bottom: -32px !important;
+}
+
+.my-n9 {
+  margin-top: -36px !important;
+  margin-bottom: -36px !important;
+}
+
+.my-n10 {
+  margin-top: -40px !important;
+  margin-bottom: -40px !important;
+}
+
+.my-n11 {
+  margin-top: -44px !important;
+  margin-bottom: -44px !important;
+}
+
+.my-n12 {
+  margin-top: -48px !important;
+  margin-bottom: -48px !important;
+}
+
+.my-n13 {
+  margin-top: -52px !important;
+  margin-bottom: -52px !important;
+}
+
+.my-n14 {
+  margin-top: -56px !important;
+  margin-bottom: -56px !important;
+}
+
+.my-n15 {
+  margin-top: -60px !important;
+  margin-bottom: -60px !important;
+}
+
+.my-n16 {
+  margin-top: -64px !important;
+  margin-bottom: -64px !important;
+}
+
+.mt-n1 {
+  margin-top: -4px !important;
+}
+
+.mt-n2 {
+  margin-top: -8px !important;
+}
+
+.mt-n3 {
+  margin-top: -12px !important;
+}
+
+.mt-n4 {
+  margin-top: -16px !important;
+}
+
+.mt-n5 {
+  margin-top: -20px !important;
+}
+
+.mt-n6 {
+  margin-top: -24px !important;
+}
+
+.mt-n7 {
+  margin-top: -28px !important;
+}
+
+.mt-n8 {
+  margin-top: -32px !important;
+}
+
+.mt-n9 {
+  margin-top: -36px !important;
+}
+
+.mt-n10 {
+  margin-top: -40px !important;
+}
+
+.mt-n11 {
+  margin-top: -44px !important;
+}
+
+.mt-n12 {
+  margin-top: -48px !important;
+}
+
+.mt-n13 {
+  margin-top: -52px !important;
+}
+
+.mt-n14 {
+  margin-top: -56px !important;
+}
+
+.mt-n15 {
+  margin-top: -60px !important;
+}
+
+.mt-n16 {
+  margin-top: -64px !important;
+}
+
+.mr-n1 {
+  margin-right: -4px !important;
+}
+
+.mr-n2 {
+  margin-right: -8px !important;
+}
+
+.mr-n3 {
+  margin-right: -12px !important;
+}
+
+.mr-n4 {
+  margin-right: -16px !important;
+}
+
+.mr-n5 {
+  margin-right: -20px !important;
+}
+
+.mr-n6 {
+  margin-right: -24px !important;
+}
+
+.mr-n7 {
+  margin-right: -28px !important;
+}
+
+.mr-n8 {
+  margin-right: -32px !important;
+}
+
+.mr-n9 {
+  margin-right: -36px !important;
+}
+
+.mr-n10 {
+  margin-right: -40px !important;
+}
+
+.mr-n11 {
+  margin-right: -44px !important;
+}
+
+.mr-n12 {
+  margin-right: -48px !important;
+}
+
+.mr-n13 {
+  margin-right: -52px !important;
+}
+
+.mr-n14 {
+  margin-right: -56px !important;
+}
+
+.mr-n15 {
+  margin-right: -60px !important;
+}
+
+.mr-n16 {
+  margin-right: -64px !important;
+}
+
+.mb-n1 {
+  margin-bottom: -4px !important;
+}
+
+.mb-n2 {
+  margin-bottom: -8px !important;
+}
+
+.mb-n3 {
+  margin-bottom: -12px !important;
+}
+
+.mb-n4 {
+  margin-bottom: -16px !important;
+}
+
+.mb-n5 {
+  margin-bottom: -20px !important;
+}
+
+.mb-n6 {
+  margin-bottom: -24px !important;
+}
+
+.mb-n7 {
+  margin-bottom: -28px !important;
+}
+
+.mb-n8 {
+  margin-bottom: -32px !important;
+}
+
+.mb-n9 {
+  margin-bottom: -36px !important;
+}
+
+.mb-n10 {
+  margin-bottom: -40px !important;
+}
+
+.mb-n11 {
+  margin-bottom: -44px !important;
+}
+
+.mb-n12 {
+  margin-bottom: -48px !important;
+}
+
+.mb-n13 {
+  margin-bottom: -52px !important;
+}
+
+.mb-n14 {
+  margin-bottom: -56px !important;
+}
+
+.mb-n15 {
+  margin-bottom: -60px !important;
+}
+
+.mb-n16 {
+  margin-bottom: -64px !important;
+}
+
+.ml-n1 {
+  margin-left: -4px !important;
+}
+
+.ml-n2 {
+  margin-left: -8px !important;
+}
+
+.ml-n3 {
+  margin-left: -12px !important;
+}
+
+.ml-n4 {
+  margin-left: -16px !important;
+}
+
+.ml-n5 {
+  margin-left: -20px !important;
+}
+
+.ml-n6 {
+  margin-left: -24px !important;
+}
+
+.ml-n7 {
+  margin-left: -28px !important;
+}
+
+.ml-n8 {
+  margin-left: -32px !important;
+}
+
+.ml-n9 {
+  margin-left: -36px !important;
+}
+
+.ml-n10 {
+  margin-left: -40px !important;
+}
+
+.ml-n11 {
+  margin-left: -44px !important;
+}
+
+.ml-n12 {
+  margin-left: -48px !important;
+}
+
+.ml-n13 {
+  margin-left: -52px !important;
+}
+
+.ml-n14 {
+  margin-left: -56px !important;
+}
+
+.ml-n15 {
+  margin-left: -60px !important;
+}
+
+.ml-n16 {
+  margin-left: -64px !important;
+}
+
+.ms-n1 {
+  margin-inline-start: -4px !important;
+}
+
+.ms-n2 {
+  margin-inline-start: -8px !important;
+}
+
+.ms-n3 {
+  margin-inline-start: -12px !important;
+}
+
+.ms-n4 {
+  margin-inline-start: -16px !important;
+}
+
+.ms-n5 {
+  margin-inline-start: -20px !important;
+}
+
+.ms-n6 {
+  margin-inline-start: -24px !important;
+}
+
+.ms-n7 {
+  margin-inline-start: -28px !important;
+}
+
+.ms-n8 {
+  margin-inline-start: -32px !important;
+}
+
+.ms-n9 {
+  margin-inline-start: -36px !important;
+}
+
+.ms-n10 {
+  margin-inline-start: -40px !important;
+}
+
+.ms-n11 {
+  margin-inline-start: -44px !important;
+}
+
+.ms-n12 {
+  margin-inline-start: -48px !important;
+}
+
+.ms-n13 {
+  margin-inline-start: -52px !important;
+}
+
+.ms-n14 {
+  margin-inline-start: -56px !important;
+}
+
+.ms-n15 {
+  margin-inline-start: -60px !important;
+}
+
+.ms-n16 {
+  margin-inline-start: -64px !important;
+}
+
+.me-n1 {
+  margin-inline-end: -4px !important;
+}
+
+.me-n2 {
+  margin-inline-end: -8px !important;
+}
+
+.me-n3 {
+  margin-inline-end: -12px !important;
+}
+
+.me-n4 {
+  margin-inline-end: -16px !important;
+}
+
+.me-n5 {
+  margin-inline-end: -20px !important;
+}
+
+.me-n6 {
+  margin-inline-end: -24px !important;
+}
+
+.me-n7 {
+  margin-inline-end: -28px !important;
+}
+
+.me-n8 {
+  margin-inline-end: -32px !important;
+}
+
+.me-n9 {
+  margin-inline-end: -36px !important;
+}
+
+.me-n10 {
+  margin-inline-end: -40px !important;
+}
+
+.me-n11 {
+  margin-inline-end: -44px !important;
+}
+
+.me-n12 {
+  margin-inline-end: -48px !important;
+}
+
+.me-n13 {
+  margin-inline-end: -52px !important;
+}
+
+.me-n14 {
+  margin-inline-end: -56px !important;
+}
+
+.me-n15 {
+  margin-inline-end: -60px !important;
+}
+
+.me-n16 {
+  margin-inline-end: -64px !important;
+}
+
+.pa-0 {
+  padding: 0px !important;
+}
+
+.pa-1 {
+  padding: 4px !important;
+}
+
+.pa-2 {
+  padding: 8px !important;
+}
+
+.pa-3 {
+  padding: 12px !important;
+}
+
+.pa-4 {
+  padding: 16px !important;
+}
+
+.pa-5 {
+  padding: 20px !important;
+}
+
+.pa-6 {
+  padding: 24px !important;
+}
+
+.pa-7 {
+  padding: 28px !important;
+}
+
+.pa-8 {
+  padding: 32px !important;
+}
+
+.pa-9 {
+  padding: 36px !important;
+}
+
+.pa-10 {
+  padding: 40px !important;
+}
+
+.pa-11 {
+  padding: 44px !important;
+}
+
+.pa-12 {
+  padding: 48px !important;
+}
+
+.pa-13 {
+  padding: 52px !important;
+}
+
+.pa-14 {
+  padding: 56px !important;
+}
+
+.pa-15 {
+  padding: 60px !important;
+}
+
+.pa-16 {
+  padding: 64px !important;
+}
+
+.px-0 {
+  padding-right: 0px !important;
+  padding-left: 0px !important;
+}
+
+.px-1 {
+  padding-right: 4px !important;
+  padding-left: 4px !important;
+}
+
+.px-2 {
+  padding-right: 8px !important;
+  padding-left: 8px !important;
+}
+
+.px-3 {
+  padding-right: 12px !important;
+  padding-left: 12px !important;
+}
+
+.px-4 {
+  padding-right: 16px !important;
+  padding-left: 16px !important;
+}
+
+.px-5 {
+  padding-right: 20px !important;
+  padding-left: 20px !important;
+}
+
+.px-6 {
+  padding-right: 24px !important;
+  padding-left: 24px !important;
+}
+
+.px-7 {
+  padding-right: 28px !important;
+  padding-left: 28px !important;
+}
+
+.px-8 {
+  padding-right: 32px !important;
+  padding-left: 32px !important;
+}
+
+.px-9 {
+  padding-right: 36px !important;
+  padding-left: 36px !important;
+}
+
+.px-10 {
+  padding-right: 40px !important;
+  padding-left: 40px !important;
+}
+
+.px-11 {
+  padding-right: 44px !important;
+  padding-left: 44px !important;
+}
+
+.px-12 {
+  padding-right: 48px !important;
+  padding-left: 48px !important;
+}
+
+.px-13 {
+  padding-right: 52px !important;
+  padding-left: 52px !important;
+}
+
+.px-14 {
+  padding-right: 56px !important;
+  padding-left: 56px !important;
+}
+
+.px-15 {
+  padding-right: 60px !important;
+  padding-left: 60px !important;
+}
+
+.px-16 {
+  padding-right: 64px !important;
+  padding-left: 64px !important;
+}
+
+.py-0 {
+  padding-top: 0px !important;
+  padding-bottom: 0px !important;
+}
+
+.py-1 {
+  padding-top: 4px !important;
+  padding-bottom: 4px !important;
+}
+
+.py-2 {
+  padding-top: 8px !important;
+  padding-bottom: 8px !important;
+}
+
+.py-3 {
+  padding-top: 12px !important;
+  padding-bottom: 12px !important;
+}
+
+.py-4 {
+  padding-top: 16px !important;
+  padding-bottom: 16px !important;
+}
+
+.py-5 {
+  padding-top: 20px !important;
+  padding-bottom: 20px !important;
+}
+
+.py-6 {
+  padding-top: 24px !important;
+  padding-bottom: 24px !important;
+}
+
+.py-7 {
+  padding-top: 28px !important;
+  padding-bottom: 28px !important;
+}
+
+.py-8 {
+  padding-top: 32px !important;
+  padding-bottom: 32px !important;
+}
+
+.py-9 {
+  padding-top: 36px !important;
+  padding-bottom: 36px !important;
+}
+
+.py-10 {
+  padding-top: 40px !important;
+  padding-bottom: 40px !important;
+}
+
+.py-11 {
+  padding-top: 44px !important;
+  padding-bottom: 44px !important;
+}
+
+.py-12 {
+  padding-top: 48px !important;
+  padding-bottom: 48px !important;
+}
+
+.py-13 {
+  padding-top: 52px !important;
+  padding-bottom: 52px !important;
+}
+
+.py-14 {
+  padding-top: 56px !important;
+  padding-bottom: 56px !important;
+}
+
+.py-15 {
+  padding-top: 60px !important;
+  padding-bottom: 60px !important;
+}
+
+.py-16 {
+  padding-top: 64px !important;
+  padding-bottom: 64px !important;
+}
+
+.pt-0 {
+  padding-top: 0px !important;
+}
+
+.pt-1 {
+  padding-top: 4px !important;
+}
+
+.pt-2 {
+  padding-top: 8px !important;
+}
+
+.pt-3 {
+  padding-top: 12px !important;
+}
+
+.pt-4 {
+  padding-top: 16px !important;
+}
+
+.pt-5 {
+  padding-top: 20px !important;
+}
+
+.pt-6 {
+  padding-top: 24px !important;
+}
+
+.pt-7 {
+  padding-top: 28px !important;
+}
+
+.pt-8 {
+  padding-top: 32px !important;
+}
+
+.pt-9 {
+  padding-top: 36px !important;
+}
+
+.pt-10 {
+  padding-top: 40px !important;
+}
+
+.pt-11 {
+  padding-top: 44px !important;
+}
+
+.pt-12 {
+  padding-top: 48px !important;
+}
+
+.pt-13 {
+  padding-top: 52px !important;
+}
+
+.pt-14 {
+  padding-top: 56px !important;
+}
+
+.pt-15 {
+  padding-top: 60px !important;
+}
+
+.pt-16 {
+  padding-top: 64px !important;
+}
+
+.pr-0 {
+  padding-right: 0px !important;
+}
+
+.pr-1 {
+  padding-right: 4px !important;
+}
+
+.pr-2 {
+  padding-right: 8px !important;
+}
+
+.pr-3 {
+  padding-right: 12px !important;
+}
+
+.pr-4 {
+  padding-right: 16px !important;
+}
+
+.pr-5 {
+  padding-right: 20px !important;
+}
+
+.pr-6 {
+  padding-right: 24px !important;
+}
+
+.pr-7 {
+  padding-right: 28px !important;
+}
+
+.pr-8 {
+  padding-right: 32px !important;
+}
+
+.pr-9 {
+  padding-right: 36px !important;
+}
+
+.pr-10 {
+  padding-right: 40px !important;
+}
+
+.pr-11 {
+  padding-right: 44px !important;
+}
+
+.pr-12 {
+  padding-right: 48px !important;
+}
+
+.pr-13 {
+  padding-right: 52px !important;
+}
+
+.pr-14 {
+  padding-right: 56px !important;
+}
+
+.pr-15 {
+  padding-right: 60px !important;
+}
+
+.pr-16 {
+  padding-right: 64px !important;
+}
+
+.pb-0 {
+  padding-bottom: 0px !important;
+}
+
+.pb-1 {
+  padding-bottom: 4px !important;
+}
+
+.pb-2 {
+  padding-bottom: 8px !important;
+}
+
+.pb-3 {
+  padding-bottom: 12px !important;
+}
+
+.pb-4 {
+  padding-bottom: 16px !important;
+}
+
+.pb-5 {
+  padding-bottom: 20px !important;
+}
+
+.pb-6 {
+  padding-bottom: 24px !important;
+}
+
+.pb-7 {
+  padding-bottom: 28px !important;
+}
+
+.pb-8 {
+  padding-bottom: 32px !important;
+}
+
+.pb-9 {
+  padding-bottom: 36px !important;
+}
+
+.pb-10 {
+  padding-bottom: 40px !important;
+}
+
+.pb-11 {
+  padding-bottom: 44px !important;
+}
+
+.pb-12 {
+  padding-bottom: 48px !important;
+}
+
+.pb-13 {
+  padding-bottom: 52px !important;
+}
+
+.pb-14 {
+  padding-bottom: 56px !important;
+}
+
+.pb-15 {
+  padding-bottom: 60px !important;
+}
+
+.pb-16 {
+  padding-bottom: 64px !important;
+}
+
+.pl-0 {
+  padding-left: 0px !important;
+}
+
+.pl-1 {
+  padding-left: 4px !important;
+}
+
+.pl-2 {
+  padding-left: 8px !important;
+}
+
+.pl-3 {
+  padding-left: 12px !important;
+}
+
+.pl-4 {
+  padding-left: 16px !important;
+}
+
+.pl-5 {
+  padding-left: 20px !important;
+}
+
+.pl-6 {
+  padding-left: 24px !important;
+}
+
+.pl-7 {
+  padding-left: 28px !important;
+}
+
+.pl-8 {
+  padding-left: 32px !important;
+}
+
+.pl-9 {
+  padding-left: 36px !important;
+}
+
+.pl-10 {
+  padding-left: 40px !important;
+}
+
+.pl-11 {
+  padding-left: 44px !important;
+}
+
+.pl-12 {
+  padding-left: 48px !important;
+}
+
+.pl-13 {
+  padding-left: 52px !important;
+}
+
+.pl-14 {
+  padding-left: 56px !important;
+}
+
+.pl-15 {
+  padding-left: 60px !important;
+}
+
+.pl-16 {
+  padding-left: 64px !important;
+}
+
+.ps-0 {
+  padding-inline-start: 0px !important;
+}
+
+.ps-1 {
+  padding-inline-start: 4px !important;
+}
+
+.ps-2 {
+  padding-inline-start: 8px !important;
+}
+
+.ps-3 {
+  padding-inline-start: 12px !important;
+}
+
+.ps-4 {
+  padding-inline-start: 16px !important;
+}
+
+.ps-5 {
+  padding-inline-start: 20px !important;
+}
+
+.ps-6 {
+  padding-inline-start: 24px !important;
+}
+
+.ps-7 {
+  padding-inline-start: 28px !important;
+}
+
+.ps-8 {
+  padding-inline-start: 32px !important;
+}
+
+.ps-9 {
+  padding-inline-start: 36px !important;
+}
+
+.ps-10 {
+  padding-inline-start: 40px !important;
+}
+
+.ps-11 {
+  padding-inline-start: 44px !important;
+}
+
+.ps-12 {
+  padding-inline-start: 48px !important;
+}
+
+.ps-13 {
+  padding-inline-start: 52px !important;
+}
+
+.ps-14 {
+  padding-inline-start: 56px !important;
+}
+
+.ps-15 {
+  padding-inline-start: 60px !important;
+}
+
+.ps-16 {
+  padding-inline-start: 64px !important;
+}
+
+.pe-0 {
+  padding-inline-end: 0px !important;
+}
+
+.pe-1 {
+  padding-inline-end: 4px !important;
+}
+
+.pe-2 {
+  padding-inline-end: 8px !important;
+}
+
+.pe-3 {
+  padding-inline-end: 12px !important;
+}
+
+.pe-4 {
+  padding-inline-end: 16px !important;
+}
+
+.pe-5 {
+  padding-inline-end: 20px !important;
+}
+
+.pe-6 {
+  padding-inline-end: 24px !important;
+}
+
+.pe-7 {
+  padding-inline-end: 28px !important;
+}
+
+.pe-8 {
+  padding-inline-end: 32px !important;
+}
+
+.pe-9 {
+  padding-inline-end: 36px !important;
+}
+
+.pe-10 {
+  padding-inline-end: 40px !important;
+}
+
+.pe-11 {
+  padding-inline-end: 44px !important;
+}
+
+.pe-12 {
+  padding-inline-end: 48px !important;
+}
+
+.pe-13 {
+  padding-inline-end: 52px !important;
+}
+
+.pe-14 {
+  padding-inline-end: 56px !important;
+}
+
+.pe-15 {
+  padding-inline-end: 60px !important;
+}
+
+.pe-16 {
+  padding-inline-end: 64px !important;
+}
+
+.rounded-0 {
+  border-radius: 0 !important;
+}
+
+.rounded-sm {
+  border-radius: 2px !important;
+}
+
+.rounded {
+  border-radius: 4px !important;
+}
+
+.rounded-lg {
+  border-radius: 8px !important;
+}
+
+.rounded-xl {
+  border-radius: 24px !important;
+}
+
+.rounded-pill {
+  border-radius: 9999px !important;
+}
+
+.rounded-circle {
+  border-radius: 50% !important;
+}
+
+.rounded-shaped {
+  border-radius: 24px 0 !important;
+}
+
+.rounded-t-0 {
+  border-top-left-radius: 0 !important;
+  border-top-right-radius: 0 !important;
+}
+
+.rounded-t-sm {
+  border-top-left-radius: 2px !important;
+  border-top-right-radius: 2px !important;
+}
+
+.rounded-t {
+  border-top-left-radius: 4px !important;
+  border-top-right-radius: 4px !important;
+}
+
+.rounded-t-lg {
+  border-top-left-radius: 8px !important;
+  border-top-right-radius: 8px !important;
+}
+
+.rounded-t-xl {
+  border-top-left-radius: 24px !important;
+  border-top-right-radius: 24px !important;
+}
+
+.rounded-t-pill {
+  border-top-left-radius: 9999px !important;
+  border-top-right-radius: 9999px !important;
+}
+
+.rounded-t-circle {
+  border-top-left-radius: 50% !important;
+  border-top-right-radius: 50% !important;
+}
+
+.rounded-t-shaped {
+  border-top-left-radius: 24px !important;
+  border-top-right-radius: 0 !important;
+}
+
+.v-locale--is-ltr .rounded-e-0 {
+  border-top-right-radius: 0 !important;
+  border-bottom-right-radius: 0 !important;
+}
+
+.v-locale--is-rtl .rounded-e-0 {
+  border-top-left-radius: 0 !important;
+  border-bottom-left-radius: 0 !important;
+}
+
+.v-locale--is-ltr .rounded-e-sm {
+  border-top-right-radius: 2px !important;
+  border-bottom-right-radius: 2px !important;
+}
+
+.v-locale--is-rtl .rounded-e-sm {
+  border-top-left-radius: 2px !important;
+  border-bottom-left-radius: 2px !important;
+}
+
+.v-locale--is-ltr .rounded-e {
+  border-top-right-radius: 4px !important;
+  border-bottom-right-radius: 4px !important;
+}
+
+.v-locale--is-rtl .rounded-e {
+  border-top-left-radius: 4px !important;
+  border-bottom-left-radius: 4px !important;
+}
+
+.v-locale--is-ltr .rounded-e-lg {
+  border-top-right-radius: 8px !important;
+  border-bottom-right-radius: 8px !important;
+}
+
+.v-locale--is-rtl .rounded-e-lg {
+  border-top-left-radius: 8px !important;
+  border-bottom-left-radius: 8px !important;
+}
+
+.v-locale--is-ltr .rounded-e-xl {
+  border-top-right-radius: 24px !important;
+  border-bottom-right-radius: 24px !important;
+}
+
+.v-locale--is-rtl .rounded-e-xl {
+  border-top-left-radius: 24px !important;
+  border-bottom-left-radius: 24px !important;
+}
+
+.v-locale--is-ltr .rounded-e-pill {
+  border-top-right-radius: 9999px !important;
+  border-bottom-right-radius: 9999px !important;
+}
+
+.v-locale--is-rtl .rounded-e-pill {
+  border-top-left-radius: 9999px !important;
+  border-bottom-left-radius: 9999px !important;
+}
+
+.v-locale--is-ltr .rounded-e-circle {
+  border-top-right-radius: 50% !important;
+  border-bottom-right-radius: 50% !important;
+}
+
+.v-locale--is-rtl .rounded-e-circle {
+  border-top-left-radius: 50% !important;
+  border-bottom-left-radius: 50% !important;
+}
+
+.v-locale--is-ltr .rounded-e-shaped {
+  border-top-right-radius: 24px !important;
+  border-bottom-right-radius: 0 !important;
+}
+
+.v-locale--is-rtl .rounded-e-shaped {
+  border-top-left-radius: 24px !important;
+  border-bottom-left-radius: 0 !important;
+}
+
+.rounded-b-0 {
+  border-bottom-left-radius: 0 !important;
+  border-bottom-right-radius: 0 !important;
+}
+
+.rounded-b-sm {
+  border-bottom-left-radius: 2px !important;
+  border-bottom-right-radius: 2px !important;
+}
+
+.rounded-b {
+  border-bottom-left-radius: 4px !important;
+  border-bottom-right-radius: 4px !important;
+}
+
+.rounded-b-lg {
+  border-bottom-left-radius: 8px !important;
+  border-bottom-right-radius: 8px !important;
+}
+
+.rounded-b-xl {
+  border-bottom-left-radius: 24px !important;
+  border-bottom-right-radius: 24px !important;
+}
+
+.rounded-b-pill {
+  border-bottom-left-radius: 9999px !important;
+  border-bottom-right-radius: 9999px !important;
+}
+
+.rounded-b-circle {
+  border-bottom-left-radius: 50% !important;
+  border-bottom-right-radius: 50% !important;
+}
+
+.rounded-b-shaped {
+  border-bottom-left-radius: 24px !important;
+  border-bottom-right-radius: 0 !important;
+}
+
+.v-locale--is-ltr .rounded-s-0 {
+  border-top-left-radius: 0 !important;
+  border-bottom-left-radius: 0 !important;
+}
+
+.v-locale--is-rtl .rounded-s-0 {
+  border-top-right-radius: 0 !important;
+  border-bottom-right-radius: 0 !important;
+}
+
+.v-locale--is-ltr .rounded-s-sm {
+  border-top-left-radius: 2px !important;
+  border-bottom-left-radius: 2px !important;
+}
+
+.v-locale--is-rtl .rounded-s-sm {
+  border-top-right-radius: 2px !important;
+  border-bottom-right-radius: 2px !important;
+}
+
+.v-locale--is-ltr .rounded-s {
+  border-top-left-radius: 4px !important;
+  border-bottom-left-radius: 4px !important;
+}
+
+.v-locale--is-rtl .rounded-s {
+  border-top-right-radius: 4px !important;
+  border-bottom-right-radius: 4px !important;
+}
+
+.v-locale--is-ltr .rounded-s-lg {
+  border-top-left-radius: 8px !important;
+  border-bottom-left-radius: 8px !important;
+}
+
+.v-locale--is-rtl .rounded-s-lg {
+  border-top-right-radius: 8px !important;
+  border-bottom-right-radius: 8px !important;
+}
+
+.v-locale--is-ltr .rounded-s-xl {
+  border-top-left-radius: 24px !important;
+  border-bottom-left-radius: 24px !important;
+}
+
+.v-locale--is-rtl .rounded-s-xl {
+  border-top-right-radius: 24px !important;
+  border-bottom-right-radius: 24px !important;
+}
+
+.v-locale--is-ltr .rounded-s-pill {
+  border-top-left-radius: 9999px !important;
+  border-bottom-left-radius: 9999px !important;
+}
+
+.v-locale--is-rtl .rounded-s-pill {
+  border-top-right-radius: 9999px !important;
+  border-bottom-right-radius: 9999px !important;
+}
+
+.v-locale--is-ltr .rounded-s-circle {
+  border-top-left-radius: 50% !important;
+  border-bottom-left-radius: 50% !important;
+}
+
+.v-locale--is-rtl .rounded-s-circle {
+  border-top-right-radius: 50% !important;
+  border-bottom-right-radius: 50% !important;
+}
+
+.v-locale--is-ltr .rounded-s-shaped {
+  border-top-left-radius: 24px !important;
+  border-bottom-left-radius: 0 !important;
+}
+
+.v-locale--is-rtl .rounded-s-shaped {
+  border-top-right-radius: 24px !important;
+  border-bottom-right-radius: 0 !important;
+}
+
+.v-locale--is-ltr .rounded-ts-0 {
+  border-top-left-radius: 0 !important;
+}
+
+.v-locale--is-rtl .rounded-ts-0 {
+  border-top-right-radius: 0 !important;
+}
+
+.v-locale--is-ltr .rounded-ts-sm {
+  border-top-left-radius: 2px !important;
+}
+
+.v-locale--is-rtl .rounded-ts-sm {
+  border-top-right-radius: 2px !important;
+}
+
+.v-locale--is-ltr .rounded-ts {
+  border-top-left-radius: 4px !important;
+}
+
+.v-locale--is-rtl .rounded-ts {
+  border-top-right-radius: 4px !important;
+}
+
+.v-locale--is-ltr .rounded-ts-lg {
+  border-top-left-radius: 8px !important;
+}
+
+.v-locale--is-rtl .rounded-ts-lg {
+  border-top-right-radius: 8px !important;
+}
+
+.v-locale--is-ltr .rounded-ts-xl {
+  border-top-left-radius: 24px !important;
+}
+
+.v-locale--is-rtl .rounded-ts-xl {
+  border-top-right-radius: 24px !important;
+}
+
+.v-locale--is-ltr .rounded-ts-pill {
+  border-top-left-radius: 9999px !important;
+}
+
+.v-locale--is-rtl .rounded-ts-pill {
+  border-top-right-radius: 9999px !important;
+}
+
+.v-locale--is-ltr .rounded-ts-circle {
+  border-top-left-radius: 50% !important;
+}
+
+.v-locale--is-rtl .rounded-ts-circle {
+  border-top-right-radius: 50% !important;
+}
+
+.v-locale--is-ltr .rounded-ts-shaped {
+  border-top-left-radius: 24px 0 !important;
+}
+
+.v-locale--is-rtl .rounded-ts-shaped {
+  border-top-right-radius: 24px 0 !important;
+}
+
+.v-locale--is-ltr .rounded-te-0 {
+  border-top-right-radius: 0 !important;
+}
+
+.v-locale--is-rtl .rounded-te-0 {
+  border-top-left-radius: 0 !important;
+}
+
+.v-locale--is-ltr .rounded-te-sm {
+  border-top-right-radius: 2px !important;
+}
+
+.v-locale--is-rtl .rounded-te-sm {
+  border-top-left-radius: 2px !important;
+}
+
+.v-locale--is-ltr .rounded-te {
+  border-top-right-radius: 4px !important;
+}
+
+.v-locale--is-rtl .rounded-te {
+  border-top-left-radius: 4px !important;
+}
+
+.v-locale--is-ltr .rounded-te-lg {
+  border-top-right-radius: 8px !important;
+}
+
+.v-locale--is-rtl .rounded-te-lg {
+  border-top-left-radius: 8px !important;
+}
+
+.v-locale--is-ltr .rounded-te-xl {
+  border-top-right-radius: 24px !important;
+}
+
+.v-locale--is-rtl .rounded-te-xl {
+  border-top-left-radius: 24px !important;
+}
+
+.v-locale--is-ltr .rounded-te-pill {
+  border-top-right-radius: 9999px !important;
+}
+
+.v-locale--is-rtl .rounded-te-pill {
+  border-top-left-radius: 9999px !important;
+}
+
+.v-locale--is-ltr .rounded-te-circle {
+  border-top-right-radius: 50% !important;
+}
+
+.v-locale--is-rtl .rounded-te-circle {
+  border-top-left-radius: 50% !important;
+}
+
+.v-locale--is-ltr .rounded-te-shaped {
+  border-top-right-radius: 24px 0 !important;
+}
+
+.v-locale--is-rtl .rounded-te-shaped {
+  border-top-left-radius: 24px 0 !important;
+}
+
+.v-locale--is-ltr .rounded-be-0 {
+  border-bottom-right-radius: 0 !important;
+}
+
+.v-locale--is-rtl .rounded-be-0 {
+  border-bottom-left-radius: 0 !important;
+}
+
+.v-locale--is-ltr .rounded-be-sm {
+  border-bottom-right-radius: 2px !important;
+}
+
+.v-locale--is-rtl .rounded-be-sm {
+  border-bottom-left-radius: 2px !important;
+}
+
+.v-locale--is-ltr .rounded-be {
+  border-bottom-right-radius: 4px !important;
+}
+
+.v-locale--is-rtl .rounded-be {
+  border-bottom-left-radius: 4px !important;
+}
+
+.v-locale--is-ltr .rounded-be-lg {
+  border-bottom-right-radius: 8px !important;
+}
+
+.v-locale--is-rtl .rounded-be-lg {
+  border-bottom-left-radius: 8px !important;
+}
+
+.v-locale--is-ltr .rounded-be-xl {
+  border-bottom-right-radius: 24px !important;
+}
+
+.v-locale--is-rtl .rounded-be-xl {
+  border-bottom-left-radius: 24px !important;
+}
+
+.v-locale--is-ltr .rounded-be-pill {
+  border-bottom-right-radius: 9999px !important;
+}
+
+.v-locale--is-rtl .rounded-be-pill {
+  border-bottom-left-radius: 9999px !important;
+}
+
+.v-locale--is-ltr .rounded-be-circle {
+  border-bottom-right-radius: 50% !important;
+}
+
+.v-locale--is-rtl .rounded-be-circle {
+  border-bottom-left-radius: 50% !important;
+}
+
+.v-locale--is-ltr .rounded-be-shaped {
+  border-bottom-right-radius: 24px 0 !important;
+}
+
+.v-locale--is-rtl .rounded-be-shaped {
+  border-bottom-left-radius: 24px 0 !important;
+}
+
+.v-locale--is-ltr .rounded-bs-0 {
+  border-bottom-left-radius: 0 !important;
+}
+
+.v-locale--is-rtl .rounded-bs-0 {
+  border-bottom-right-radius: 0 !important;
+}
+
+.v-locale--is-ltr .rounded-bs-sm {
+  border-bottom-left-radius: 2px !important;
+}
+
+.v-locale--is-rtl .rounded-bs-sm {
+  border-bottom-right-radius: 2px !important;
+}
+
+.v-locale--is-ltr .rounded-bs {
+  border-bottom-left-radius: 4px !important;
+}
+
+.v-locale--is-rtl .rounded-bs {
+  border-bottom-right-radius: 4px !important;
+}
+
+.v-locale--is-ltr .rounded-bs-lg {
+  border-bottom-left-radius: 8px !important;
+}
+
+.v-locale--is-rtl .rounded-bs-lg {
+  border-bottom-right-radius: 8px !important;
+}
+
+.v-locale--is-ltr .rounded-bs-xl {
+  border-bottom-left-radius: 24px !important;
+}
+
+.v-locale--is-rtl .rounded-bs-xl {
+  border-bottom-right-radius: 24px !important;
+}
+
+.v-locale--is-ltr .rounded-bs-pill {
+  border-bottom-left-radius: 9999px !important;
+}
+
+.v-locale--is-rtl .rounded-bs-pill {
+  border-bottom-right-radius: 9999px !important;
+}
+
+.v-locale--is-ltr .rounded-bs-circle {
+  border-bottom-left-radius: 50% !important;
+}
+
+.v-locale--is-rtl .rounded-bs-circle {
+  border-bottom-right-radius: 50% !important;
+}
+
+.v-locale--is-ltr .rounded-bs-shaped {
+  border-bottom-left-radius: 24px 0 !important;
+}
+
+.v-locale--is-rtl .rounded-bs-shaped {
+  border-bottom-right-radius: 24px 0 !important;
+}
+
+.border-0 {
+  border-width: 0 !important;
+  border-style: solid !important;
+  border-color: rgba(var(--v-border-color), var(--v-border-opacity)) !important;
+}
+
+.border {
+  border-width: thin !important;
+  border-style: solid !important;
+  border-color: rgba(var(--v-border-color), var(--v-border-opacity)) !important;
+}
+
+.border-thin {
+  border-width: thin !important;
+  border-style: solid !important;
+  border-color: rgba(var(--v-border-color), var(--v-border-opacity)) !important;
+}
+
+.border-sm {
+  border-width: 1px !important;
+  border-style: solid !important;
+  border-color: rgba(var(--v-border-color), var(--v-border-opacity)) !important;
+}
+
+.border-md {
+  border-width: 2px !important;
+  border-style: solid !important;
+  border-color: rgba(var(--v-border-color), var(--v-border-opacity)) !important;
+}
+
+.border-lg {
+  border-width: 4px !important;
+  border-style: solid !important;
+  border-color: rgba(var(--v-border-color), var(--v-border-opacity)) !important;
+}
+
+.border-xl {
+  border-width: 8px !important;
+  border-style: solid !important;
+  border-color: rgba(var(--v-border-color), var(--v-border-opacity)) !important;
+}
+
+.border-opacity-0 {
+  --v-border-opacity: 0 !important;
+}
+
+.border-opacity {
+  --v-border-opacity: 0.12 !important;
+}
+
+.border-opacity-25 {
+  --v-border-opacity: 0.25 !important;
+}
+
+.border-opacity-50 {
+  --v-border-opacity: 0.5 !important;
+}
+
+.border-opacity-75 {
+  --v-border-opacity: 0.75 !important;
+}
+
+.border-opacity-100 {
+  --v-border-opacity: 1 !important;
+}
+
+.border-t-0 {
+  border-block-start-width: 0 !important;
+  border-block-start-style: solid !important;
+  border-block-start-color: rgba(var(--v-border-color), var(--v-border-opacity)) !important;
+}
+
+.border-t {
+  border-block-start-width: thin !important;
+  border-block-start-style: solid !important;
+  border-block-start-color: rgba(var(--v-border-color), var(--v-border-opacity)) !important;
+}
+
+.border-t-thin {
+  border-block-start-width: thin !important;
+  border-block-start-style: solid !important;
+  border-block-start-color: rgba(var(--v-border-color), var(--v-border-opacity)) !important;
+}
+
+.border-t-sm {
+  border-block-start-width: 1px !important;
+  border-block-start-style: solid !important;
+  border-block-start-color: rgba(var(--v-border-color), var(--v-border-opacity)) !important;
+}
+
+.border-t-md {
+  border-block-start-width: 2px !important;
+  border-block-start-style: solid !important;
+  border-block-start-color: rgba(var(--v-border-color), var(--v-border-opacity)) !important;
+}
+
+.border-t-lg {
+  border-block-start-width: 4px !important;
+  border-block-start-style: solid !important;
+  border-block-start-color: rgba(var(--v-border-color), var(--v-border-opacity)) !important;
+}
+
+.border-t-xl {
+  border-block-start-width: 8px !important;
+  border-block-start-style: solid !important;
+  border-block-start-color: rgba(var(--v-border-color), var(--v-border-opacity)) !important;
+}
+
+.border-e-0 {
+  border-inline-end-width: 0 !important;
+  border-inline-end-style: solid !important;
+  border-inline-end-color: rgba(var(--v-border-color), var(--v-border-opacity)) !important;
+}
+
+.border-e {
+  border-inline-end-width: thin !important;
+  border-inline-end-style: solid !important;
+  border-inline-end-color: rgba(var(--v-border-color), var(--v-border-opacity)) !important;
+}
+
+.border-e-thin {
+  border-inline-end-width: thin !important;
+  border-inline-end-style: solid !important;
+  border-inline-end-color: rgba(var(--v-border-color), var(--v-border-opacity)) !important;
+}
+
+.border-e-sm {
+  border-inline-end-width: 1px !important;
+  border-inline-end-style: solid !important;
+  border-inline-end-color: rgba(var(--v-border-color), var(--v-border-opacity)) !important;
+}
+
+.border-e-md {
+  border-inline-end-width: 2px !important;
+  border-inline-end-style: solid !important;
+  border-inline-end-color: rgba(var(--v-border-color), var(--v-border-opacity)) !important;
+}
+
+.border-e-lg {
+  border-inline-end-width: 4px !important;
+  border-inline-end-style: solid !important;
+  border-inline-end-color: rgba(var(--v-border-color), var(--v-border-opacity)) !important;
+}
+
+.border-e-xl {
+  border-inline-end-width: 8px !important;
+  border-inline-end-style: solid !important;
+  border-inline-end-color: rgba(var(--v-border-color), var(--v-border-opacity)) !important;
+}
+
+.border-b-0 {
+  border-block-end-width: 0 !important;
+  border-block-end-style: solid !important;
+  border-block-end-color: rgba(var(--v-border-color), var(--v-border-opacity)) !important;
+}
+
+.border-b {
+  border-block-end-width: thin !important;
+  border-block-end-style: solid !important;
+  border-block-end-color: rgba(var(--v-border-color), var(--v-border-opacity)) !important;
+}
+
+.border-b-thin {
+  border-block-end-width: thin !important;
+  border-block-end-style: solid !important;
+  border-block-end-color: rgba(var(--v-border-color), var(--v-border-opacity)) !important;
+}
+
+.border-b-sm {
+  border-block-end-width: 1px !important;
+  border-block-end-style: solid !important;
+  border-block-end-color: rgba(var(--v-border-color), var(--v-border-opacity)) !important;
+}
+
+.border-b-md {
+  border-block-end-width: 2px !important;
+  border-block-end-style: solid !important;
+  border-block-end-color: rgba(var(--v-border-color), var(--v-border-opacity)) !important;
+}
+
+.border-b-lg {
+  border-block-end-width: 4px !important;
+  border-block-end-style: solid !important;
+  border-block-end-color: rgba(var(--v-border-color), var(--v-border-opacity)) !important;
+}
+
+.border-b-xl {
+  border-block-end-width: 8px !important;
+  border-block-end-style: solid !important;
+  border-block-end-color: rgba(var(--v-border-color), var(--v-border-opacity)) !important;
+}
+
+.border-s-0 {
+  border-inline-start-width: 0 !important;
+  border-inline-start-style: solid !important;
+  border-inline-start-color: rgba(var(--v-border-color), var(--v-border-opacity)) !important;
+}
+
+.border-s {
+  border-inline-start-width: thin !important;
+  border-inline-start-style: solid !important;
+  border-inline-start-color: rgba(var(--v-border-color), var(--v-border-opacity)) !important;
+}
+
+.border-s-thin {
+  border-inline-start-width: thin !important;
+  border-inline-start-style: solid !important;
+  border-inline-start-color: rgba(var(--v-border-color), var(--v-border-opacity)) !important;
+}
+
+.border-s-sm {
+  border-inline-start-width: 1px !important;
+  border-inline-start-style: solid !important;
+  border-inline-start-color: rgba(var(--v-border-color), var(--v-border-opacity)) !important;
+}
+
+.border-s-md {
+  border-inline-start-width: 2px !important;
+  border-inline-start-style: solid !important;
+  border-inline-start-color: rgba(var(--v-border-color), var(--v-border-opacity)) !important;
+}
+
+.border-s-lg {
+  border-inline-start-width: 4px !important;
+  border-inline-start-style: solid !important;
+  border-inline-start-color: rgba(var(--v-border-color), var(--v-border-opacity)) !important;
+}
+
+.border-s-xl {
+  border-inline-start-width: 8px !important;
+  border-inline-start-style: solid !important;
+  border-inline-start-color: rgba(var(--v-border-color), var(--v-border-opacity)) !important;
+}
+
+.border-solid {
+  border-style: solid !important;
+}
+
+.border-dashed {
+  border-style: dashed !important;
+}
+
+.border-dotted {
+  border-style: dotted !important;
+}
+
+.border-double {
+  border-style: double !important;
+}
+
+.border-none {
+  border-style: none !important;
+}
+
+.text-left {
+  text-align: left !important;
+}
+
+.text-right {
+  text-align: right !important;
+}
+
+.text-center {
+  text-align: center !important;
+}
+
+.text-justify {
+  text-align: justify !important;
+}
+
+.text-start {
+  text-align: start !important;
+}
+
+.text-end {
+  text-align: end !important;
+}
+
+.text-decoration-line-through {
+  text-decoration: line-through !important;
+}
+
+.text-decoration-none {
+  text-decoration: none !important;
+}
+
+.text-decoration-overline {
+  text-decoration: overline !important;
+}
+
+.text-decoration-underline {
+  text-decoration: underline !important;
+}
+
+.text-wrap {
+  white-space: normal !important;
+}
+
+.text-no-wrap {
+  white-space: nowrap !important;
+}
+
+.text-pre {
+  white-space: pre !important;
+}
+
+.text-pre-line {
+  white-space: pre-line !important;
+}
+
+.text-pre-wrap {
+  white-space: pre-wrap !important;
+}
+
+.text-break {
+  overflow-wrap: break-word !important;
+  word-break: break-word !important;
+}
+
+.opacity-hover {
+  opacity: var(--v-hover-opacity) !important;
+}
+
+.opacity-focus {
+  opacity: var(--v-focus-opacity) !important;
+}
+
+.opacity-selected {
+  opacity: var(--v-selected-opacity) !important;
+}
+
+.opacity-activated {
+  opacity: var(--v-activated-opacity) !important;
+}
+
+.opacity-pressed {
+  opacity: var(--v-pressed-opacity) !important;
+}
+
+.opacity-dragged {
+  opacity: var(--v-dragged-opacity) !important;
+}
+
+.opacity-0 {
+  opacity: 0 !important;
+}
+
+.opacity-10 {
+  opacity: 0.1 !important;
+}
+
+.opacity-20 {
+  opacity: 0.2 !important;
+}
+
+.opacity-30 {
+  opacity: 0.3 !important;
+}
+
+.opacity-40 {
+  opacity: 0.4 !important;
+}
+
+.opacity-50 {
+  opacity: 0.5 !important;
+}
+
+.opacity-60 {
+  opacity: 0.6 !important;
+}
+
+.opacity-70 {
+  opacity: 0.7 !important;
+}
+
+.opacity-80 {
+  opacity: 0.8 !important;
+}
+
+.opacity-90 {
+  opacity: 0.9 !important;
+}
+
+.opacity-100 {
+  opacity: 1 !important;
+}
+
+.text-high-emphasis {
+  color: rgba(var(--v-theme-on-background), var(--v-high-emphasis-opacity)) !important;
+}
+
+.text-medium-emphasis {
+  color: rgba(var(--v-theme-on-background), var(--v-medium-emphasis-opacity)) !important;
+}
+
+.text-disabled {
+  color: rgba(var(--v-theme-on-background), var(--v-disabled-opacity)) !important;
+}
+
+.text-truncate {
+  white-space: nowrap !important;
+  overflow: hidden !important;
+  text-overflow: ellipsis !important;
+}
+
+.text-h1 {
+  font-size: 6rem !important;
+  font-weight: 300;
+  line-height: 1;
+  letter-spacing: -0.015625em !important;
+  font-family: "Roboto", sans-serif;
+  text-transform: none !important;
+}
+
+.text-h2 {
+  font-size: 3.75rem !important;
+  font-weight: 300;
+  line-height: 1;
+  letter-spacing: -0.0083333333em !important;
+  font-family: "Roboto", sans-serif;
+  text-transform: none !important;
+}
+
+.text-h3 {
+  font-size: 3rem !important;
+  font-weight: 400;
+  line-height: 1.05;
+  letter-spacing: normal !important;
+  font-family: "Roboto", sans-serif;
+  text-transform: none !important;
+}
+
+.text-h4 {
+  font-size: 2.125rem !important;
+  font-weight: 400;
+  line-height: 1.175;
+  letter-spacing: 0.0073529412em !important;
+  font-family: "Roboto", sans-serif;
+  text-transform: none !important;
+}
+
+.text-h5 {
+  font-size: 1.5rem !important;
+  font-weight: 400;
+  line-height: 1.333;
+  letter-spacing: normal !important;
+  font-family: "Roboto", sans-serif;
+  text-transform: none !important;
+}
+
+.text-h6 {
+  font-size: 1.25rem !important;
+  font-weight: 500;
+  line-height: 1.6;
+  letter-spacing: 0.0125em !important;
+  font-family: "Roboto", sans-serif;
+  text-transform: none !important;
+}
+
+.text-subtitle-1 {
+  font-size: 1rem !important;
+  font-weight: normal;
+  line-height: 1.75;
+  letter-spacing: 0.009375em !important;
+  font-family: "Roboto", sans-serif;
+  text-transform: none !important;
+}
+
+.text-subtitle-2 {
+  font-size: 0.875rem !important;
+  font-weight: 500;
+  line-height: 1.6;
+  letter-spacing: 0.0071428571em !important;
+  font-family: "Roboto", sans-serif;
+  text-transform: none !important;
+}
+
+.text-body-1 {
+  font-size: 1rem !important;
+  font-weight: 400;
+  line-height: 1.5;
+  letter-spacing: 0.03125em !important;
+  font-family: "Roboto", sans-serif;
+  text-transform: none !important;
+}
+
+.text-body-2 {
+  font-size: 0.875rem !important;
+  font-weight: 400;
+  line-height: 1.425;
+  letter-spacing: 0.0178571429em !important;
+  font-family: "Roboto", sans-serif;
+  text-transform: none !important;
+}
+
+.text-button {
+  font-size: 0.875rem !important;
+  font-weight: 500;
+  line-height: 2.6;
+  letter-spacing: 0.0892857143em !important;
+  font-family: "Roboto", sans-serif;
+  text-transform: uppercase !important;
+}
+
+.text-caption {
+  font-size: 0.75rem !important;
+  font-weight: 400;
+  line-height: 1.667;
+  letter-spacing: 0.0333333333em !important;
+  font-family: "Roboto", sans-serif;
+  text-transform: none !important;
+}
+
+.text-overline {
+  font-size: 0.75rem !important;
+  font-weight: 500;
+  line-height: 2.667;
+  letter-spacing: 0.1666666667em !important;
+  font-family: "Roboto", sans-serif;
+  text-transform: uppercase !important;
+}
+
+.text-none {
+  text-transform: none !important;
+}
+
+.text-capitalize {
+  text-transform: capitalize !important;
+}
+
+.text-lowercase {
+  text-transform: lowercase !important;
+}
+
+.text-uppercase {
+  text-transform: uppercase !important;
+}
+
+.font-weight-thin {
+  font-weight: 100 !important;
+}
+
+.font-weight-light {
+  font-weight: 300 !important;
+}
+
+.font-weight-regular {
+  font-weight: 400 !important;
+}
+
+.font-weight-medium {
+  font-weight: 500 !important;
+}
+
+.font-weight-bold {
+  font-weight: 700 !important;
+}
+
+.font-weight-black {
+  font-weight: 900 !important;
+}
+
+.font-italic {
+  font-style: italic !important;
+}
+
+.text-mono {
+  font-family: monospace !important;
+}
+
+.position-static {
+  position: static !important;
+}
+
+.position-relative {
+  position: relative !important;
+}
+
+.position-fixed {
+  position: fixed !important;
+}
+
+.position-absolute {
+  position: absolute !important;
+}
+
+.position-sticky {
+  position: sticky !important;
+}
+
+.top-0 {
+  top: 0 !important;
+}
+
+.right-0 {
+  right: 0 !important;
+}
+
+.bottom-0 {
+  bottom: 0 !important;
+}
+
+.left-0 {
+  left: 0 !important;
+}
+
+.cursor-auto {
+  cursor: auto !important;
+}
+
+.cursor-default {
+  cursor: default !important;
+}
+
+.cursor-pointer {
+  cursor: pointer !important;
+}
+
+.cursor-wait {
+  cursor: wait !important;
+}
+
+.cursor-text {
+  cursor: text !important;
+}
+
+.cursor-move {
+  cursor: move !important;
+}
+
+.cursor-help {
+  cursor: help !important;
+}
+
+.cursor-not-allowed {
+  cursor: not-allowed !important;
+}
+
+.cursor-progress {
+  cursor: progress !important;
+}
+
+.cursor-grab {
+  cursor: grab !important;
+}
+
+.cursor-grabbing {
+  cursor: grabbing !important;
+}
+
+.cursor-none {
+  cursor: none !important;
+}
+
+.fill-height {
+  height: 100% !important;
 }

--- a/src/components/HeaderComponent.vue
+++ b/src/components/HeaderComponent.vue
@@ -87,7 +87,6 @@
             <v-speed-dial
               scrim="true"
               location="bottom center"
-              theme=""
               transition="fade-transition"
             >
               <template v-slot:activator="{props: activatorProps}">
@@ -111,24 +110,16 @@
 </template>
 
 <style scoped >
-
-::v-deep .v-field--variant-filled .v-field__overlay {
+  header :deep(.v-field__outline) {display:none;}
+  header :deep(.v-field--variant-filled .v-field__overlay) {
     background-color: transparent;
     border: none;
   }
-  ::v-deep .v-field--variant-filled .v-field__outline::before,
-  .v-field--variant-underlined .v-field__outline::before {
-    display: none;
-  }
-  ::v-deep .v-field--variant-filled .v-field__outline::after,
-  .v-field--variant-underlined .v-field__outline::after {
-    display: none;
-  }
-  ::v-deep .v-select .v-select__selection-text {
+  header :deep(.v-select .v-select__selection-text) {
     font-weight: bold;
   }
-  ::v-deep .v-field__input {
-    padding-left: 0;
+  header :deep(.v-field__input) {
+    padding-left: 4px;
   }
 
 </style>


### PR DESCRIPTION
- 기본 vuetify/styles에서 import하던 코드 컬러 및 반응형 관련된 옵션 지우고 추가
- v-deep의 경우 ::deep 이 deprecated된 속성이라고 콘솔에 에러 나서 :deep() 선택자로 변경. 앞에 제한할 선택자 있어야합니다. ex)
:deep(v-btn) -> error
.page :deep(v-btn) -> OK