### PR TITLE
Feat: 레시피 메인 & 상세페이지 기능 구현

### DIFF
--- a/src/apis/recipeApi.ts
+++ b/src/apis/recipeApi.ts
@@ -12,7 +12,7 @@ interface RecipeParams {
 
 const apiKey = import.meta.env.VITE_RECIPE_API_KEY; // API 키 가져오기
 
-export const fetchRecipes = async (params: RecipeParams): Promise<RecipeResponse> => {
+export const fetchRecipeList = async (params: RecipeParams): Promise<RecipeResponse> => {
   try {
     const {page, RCP_NM, RCP_PAT2, RCP_PARTS_DTLS} = params;
     const startIdx = (page - 1) * 20 + 1;
@@ -52,8 +52,20 @@ export const fetchRecipes = async (params: RecipeParams): Promise<RecipeResponse
     // RCP_PARTS_DTLS 1개 이하일 때
     const url = `/${apiKey}/COOKRCP01/json/${startIdx}/${endIdx}/${RCP_NM ? `RCP_NM=${RCP_NM}&` : ''}${RCP_PAT2 ? `RCP_PAT2=${RCP_PAT2}&` : ''}${RCP_PARTS_DTLS.length > 0 ? `RCP_PARTS_DTLS=${RCP_PARTS_DTLS[0]}` : ''}`;
     const response = await recipeApiInstance.get<RecipeResponse>(url);
-    console.log(response.data);
+    // console.log(response.data);
     return response.data;
+  } catch (error) {
+    console.error('Error fetching recipes:', error);
+    throw error;
+  }
+};
+
+export const fetchRecipe = async (recipeName: string): Promise<Recipe> => {
+  try {
+    const url = `/${apiKey}/COOKRCP01/json/${1}/${10}/RCP_NM=${recipeName}`;
+    const response = await recipeApiInstance.get<RecipeResponse>(url);
+    // console.log(response.data);
+    return response.data.COOKRCP01.row[0];
   } catch (error) {
     console.error('Error fetching recipes:', error);
     throw error;

--- a/src/apis/youtubeApi.ts
+++ b/src/apis/youtubeApi.ts
@@ -1,0 +1,22 @@
+import type {YoutubeResponse} from '@/types/youtubeResponse';
+import {youtubeApiInstance} from '@/utils/axiosInstance';
+
+const apiKey = import.meta.env.VITE_YOUTUBE_API_KEY; // API 키 가져오기
+
+export const fetchYoutube = async (keyword: string): Promise<YoutubeResponse> => {
+  try {
+    const parameters = {
+      q: keyword,
+      type: 'video',
+      maxResults: '2',
+      videoDuration: 'medium',
+      videoEmbeddable: true,
+    };
+    const response = await youtubeApiInstance.get<YoutubeResponse>('/search', {params: parameters});
+    // console.log(response.data);
+    return response.data;
+  } catch (error) {
+    console.error('Error fetching youtube:', error);
+    throw error;
+  }
+};

--- a/src/apis/youtubeApi.ts
+++ b/src/apis/youtubeApi.ts
@@ -1,4 +1,4 @@
-import type {YoutubeResponse} from '@/types/youtubeResponse';
+import type {YoutubeResponse} from '@/types/YoutubeResponse';
 import {youtubeApiInstance} from '@/utils/axiosInstance';
 
 const apiKey = import.meta.env.VITE_YOUTUBE_API_KEY; // API 키 가져오기

--- a/src/components/recipe/DoughnutChart.vue
+++ b/src/components/recipe/DoughnutChart.vue
@@ -12,44 +12,44 @@
   const props = defineProps<Props>();
 
   const rid = (nutrition: string): number => {
-    if (nutrition === 'INFO_NA') {
+    if (nutrition === 'sodium') {
       return 2000;
-    } else if (nutrition === 'INFO_FAT') {
+    } else if (nutrition === 'fat') {
       return 54;
-    } else if (nutrition === 'INFO_ENG') {
+    } else if (nutrition === 'calories') {
       return 2000;
-    } else if (nutrition === 'INFO_CAR') {
+    } else if (nutrition === 'carbohydrates') {
       return 324;
-    } else if (nutrition === 'INFO_PRO') {
+    } else if (nutrition === 'protein') {
       return 55;
     }
     return 0;
   };
 
   const color = (nutrition: string) => {
-    if (nutrition === 'INFO_NA') {
+    if (nutrition === 'sodium') {
       return '#03d8b1';
-    } else if (nutrition === 'INFO_FAT') {
+    } else if (nutrition === 'fat') {
       return '#f25267';
-    } else if (nutrition === 'INFO_ENG') {
+    } else if (nutrition === 'calories') {
       return '#f89a00';
-    } else if (nutrition === 'INFO_CAR') {
+    } else if (nutrition === 'carbohydrates') {
       return '#b05bff';
-    } else if (nutrition === 'INFO_PRO') {
+    } else if (nutrition === 'protein') {
       return '#00bdec';
     }
   };
 
   const label = (nutrition: string) => {
-    if (nutrition === 'INFO_NA') {
+    if (nutrition === 'sodium') {
       return '나트륨(mg)';
-    } else if (nutrition === 'INFO_FAT') {
+    } else if (nutrition === 'fat') {
       return '지방(g)';
-    } else if (nutrition === 'INFO_ENG') {
+    } else if (nutrition === 'calories') {
       return '열량(kcal)';
-    } else if (nutrition === 'INFO_CAR') {
+    } else if (nutrition === 'carbohydrates') {
       return '탄수화물(g)';
-    } else if (nutrition === 'INFO_PRO') {
+    } else if (nutrition === 'protein') {
       return '단백질(g)';
     }
   };

--- a/src/components/recipe/RecipePostList.vue
+++ b/src/components/recipe/RecipePostList.vue
@@ -10,7 +10,7 @@
 </script>
 
 <template>
-  <div class="flex h-[124px] w-full">
+  <div class="flex h-[124px] w-full cursor-pointer">
     <div class="min-w-[124px] w-[124px] rounded-[16px] overflow-hidden shrink-0">
       <div
         :style="{backgroundImage: `url(${props.image})`}"

--- a/src/components/recipe/RecipeRectangleCard.vue
+++ b/src/components/recipe/RecipeRectangleCard.vue
@@ -1,17 +1,17 @@
 <script setup lang="ts">
-interface Props {
-  image: string;
-  title: string;
-}
+  interface Props {
+    image: string;
+    title: string;
+  }
 
-const props = defineProps<Props>();
+  const props = defineProps<Props>();
 </script>
 
 <template>
-  <div class="flex flex-col gap-[16px] w-[516px]">
+  <div class="flex flex-col gap-[16px] w-[516px] cursor-pointer">
     <div class="h-[344px] overflow-hidden rounded-[12px]">
       <div
-        :style="{ backgroundImage: `url(${props.image})` }"
+        :style="{backgroundImage: `url(${props.image})`}"
         class="w-full h-full bg-cover bg-center"
       ></div>
     </div>

--- a/src/components/recipe/RecipeSquareCard.vue
+++ b/src/components/recipe/RecipeSquareCard.vue
@@ -14,7 +14,10 @@
 </script>
 
 <template>
-  <div :style="{width: size + 'px', height: size + 'px'}" class="overflow-hidden rounded-[20px]">
+  <div
+    :style="{width: size + 'px', height: size + 'px'}"
+    class="overflow-hidden rounded-[20px] cursor-pointer"
+  >
     <div :style="{backgroundImage: `url(${image})`}" class="w-full h-full bg-cover bg-center">
       <div
         :class="

--- a/src/components/recipe/RecipeSquareCard.vue
+++ b/src/components/recipe/RecipeSquareCard.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+  import {useAttrs} from 'vue';
   interface Props {
     image: string;
     title: string;
@@ -7,6 +8,9 @@
   }
 
   defineProps<Props>();
+
+  defineOptions({inheritAttrs: false}); // 루트 요소에 attrs 자동 상속 비활성화
+  const attrs = useAttrs();
 </script>
 
 <template>
@@ -21,6 +25,7 @@
               : 'bg-linear-to-t from-mono-900/40 to-mono-900/0 to-[42%] px-[16px] py-[12px]'
         "
         class="w-full h-full text-mono-050 flex items-end"
+        v-bind="attrs"
       >
         <div class="flex flex-col gap-1">
           <div v-if="subtitle" class="text-[20px] leading-[24px] font-regular">

--- a/src/components/recipe/SearchBarRounded.vue
+++ b/src/components/recipe/SearchBarRounded.vue
@@ -11,7 +11,7 @@
   const route = useRoute();
 
   // 이벤트 정의
-  const emit = defineEmits(['update:modelValue']);
+  const emit = defineEmits(['update:modelValue', 'search']);
 
   // 검색어
   const searchText = ref<string>('');
@@ -42,6 +42,7 @@
       emit('update:modelValue', [...props.modelValue, trimmedValue]);
       searchText.value = ''; // 입력값 초기화
     }
+    emit('search', trimmedValue);
   };
 
   // modelValue가 변경될 때 searchText를 자동 업데이트 (초기화하면 값 비우는 용도)
@@ -72,7 +73,7 @@
       "
       class="outline-none text-mono-700"
     />
-    <button @click="updateValue">
+    <button @click="updateValue" class="cursor-pointer">
       <v-icon :size="long ? '40px' : '24px'">mdi-magnify</v-icon>
     </button>
   </div>

--- a/src/types/YoutubeResponse.ts
+++ b/src/types/YoutubeResponse.ts
@@ -1,0 +1,34 @@
+export interface YoutubeResponse {
+  kind: string;
+  etag: string;
+  nextPageToken: string;
+  prevPageToken: string;
+  regionCode: string;
+  pageInfo: {
+    totalResults: number;
+    resultsPerPage: number;
+  };
+  items: Items[];
+}
+
+export interface Items {
+  kind: string;
+  etag: string;
+  id: {kind: string; videoId: string};
+  snippet: {
+    publishedAt: string;
+    channelId: string;
+    title: string;
+    description: string;
+    thumbnails: {default: Thumbnail; medium: Thumbnail; high: Thumbnail};
+    channelTitle: string;
+    liveBroadcastContent: string;
+    publishTime: string;
+  };
+}
+
+export interface Thumbnail {
+  url: string;
+  width: number;
+  height: number;
+}

--- a/src/utils/axiosInstance.ts
+++ b/src/utils/axiosInstance.ts
@@ -1,6 +1,6 @@
 import axios from 'axios';
 
-const recipeApiInstance = axios.create({
+export const recipeApiInstance = axios.create({
   baseURL: '/recipeAPI',
   params: {
     keyId: import.meta.env.VITE_RECIPE_API_KEY,
@@ -11,4 +11,10 @@ const recipeApiInstance = axios.create({
   },
 });
 
-export {recipeApiInstance};
+export const youtubeApiInstance = axios.create({
+  baseURL: 'https://www.googleapis.com/youtube/v3',
+  params: {
+    key: import.meta.env.VITE_YOUTUBE_API_KEY,
+    part: 'snippet', //part: youtube data api를 받을 때 매개변수 필수 속성
+  },
+});

--- a/src/views/RecipeDetailView.vue
+++ b/src/views/RecipeDetailView.vue
@@ -1,70 +1,34 @@
 <script setup lang="ts">
-  import type RecipeResponse from '@/types/RecipeResponse';
   import BannerComponent from '@/components/BannerComponent.vue';
   import BookmarkButton from '@/components/BookmarkButton.vue';
   import DoughnutChart from '@/components/recipe/DoughnutChart.vue';
   import ShareButton from '@/components/ShareButton.vue';
-  import {computed, reactive, ref} from 'vue';
+  import {onMounted, watch, ref} from 'vue';
+  import {useRoute} from 'vue-router';
+  import {fetchRecipe} from '@/apis/recipeApi';
+  import type {Recipe} from '@/types/RecipeResponse';
 
-  const recipeData: RecipeResponse = reactive({
-    RCP_NM: '저염된장 삼치구이',
-    RCP_PARTS_DTLS:
-      '•필수재료 : 삼치(140g), 치커리(35g), 전분가루(10g)\n•구이소스 : 일본된장(5g), 청주(5g)\n•곁들임소스 : 유자청(15g), 다진마늘(5g), 청고추(15g), 홍고추(20g)',
-    RCP_PAT2: '반찬',
-    RCP_WAY2: '굽기',
-    RCP_SEQ: '430',
-    INFO_WGT: '130',
-    INFO_ENG: '196.3', // 열량
-    INFO_CAR: '5.8', // 탄수화물
-    INFO_NA: '168.8', // 나트륨
-    INFO_PRO: '18.9', // 단백질
-    INFO_FAT: '10.8', // 지방
-    HASH_TAG: '일본된장',
-    ATT_FILE_NO_MK:
-      'http://www.foodsafetykorea.go.kr/uploadimg/20230306/20230306050812_1678090092306.jpg',
-    ATT_FILE_NO_MAIN:
-      'http://www.foodsafetykorea.go.kr/uploadimg/20230306/20230306050759_1678090079442.jpg',
-    MANUAL01: '1. 삼치는 세척 후 전분가루로 옷을 입혀준다.',
-    MANUAL02: '2. 일본된장과 청주를 섞어 구이소스를 만들어 삼치를 재운다.',
-    MANUAL03: '3. 청고추와 홍고추는 곱게 다지고 치커리는 적당하게 잘라서 물에 담가준다.',
-    MANUAL04: '4. 유자청, 다진마늘, 다진 청고추와 홍고추를 섞어 곁들임소스를 만든다.',
-    MANUAL05: '5. 재워두었던 삼치를 굽는다.',
-    MANUAL06: '6. 접시에 구운 삼치와 치커리를 올리고 치커리를 올리고 곁들임소스를 뿌려 완성한다.',
-    MANUAL07: '',
-    MANUAL08: '',
-    MANUAL09: '',
-    MANUAL10: '',
-    MANUAL11: '',
-    MANUAL12: '',
-    MANUAL13: '',
-    MANUAL14: '',
-    MANUAL15: '',
-    MANUAL16: '',
-    MANUAL17: '',
-    MANUAL18: '',
-    MANUAL19: '',
-    MANUAL20: '',
+  interface Nutrition {
+    calories: number;
+    sodium: number;
+    carbohydrates: number;
+    protein: number;
+    fat: number;
+  }
+
+  const route = useRoute();
+  const paramId = ref(route.params.id);
+  const recipeData = ref<Recipe | null>(null);
+  const nutrition = ref<Nutrition>({
+    calories: 0,
+    sodium: 0,
+    carbohydrates: 0,
+    protein: 0,
+    fat: 0,
   });
-
-  // 영양 정보 데이터 가공
-  const {INFO_ENG, INFO_NA, INFO_PRO, INFO_FAT, INFO_CAR} = recipeData;
-  const nutrition = {
-    INFO_ENG: parseFloat(INFO_ENG),
-    INFO_NA: parseFloat(INFO_NA),
-    INFO_CAR: parseFloat(INFO_CAR),
-    INFO_PRO: parseFloat(INFO_PRO),
-    INFO_FAT: parseFloat(INFO_FAT),
-  };
-
-  // 요리 방법 데이터 가공
-  const manuals = computed(() =>
-    Object.entries(recipeData)
-      .filter(
-        ([key, value]) =>
-          key.startsWith('MANUAL') && !key.startsWith('MANUAL_IMG') && value.trim() !== '',
-      )
-      .map(([_, value]) => value),
-  );
+  const manuals = ref<string[]>([]);
+  const isLoading = ref(false);
+  const error = ref<string | null>(null);
 
   // 북마크 상태 관리
   const isBookmarked = ref(false);
@@ -72,6 +36,41 @@
   const toggleBookmark = () => {
     isBookmarked.value = !isBookmarked.value;
   };
+
+  onMounted(async () => {
+    // api 호출
+    try {
+      isLoading.value = true;
+      const data = await fetchRecipe(String(paramId.value));
+      recipeData.value = data;
+    } catch (err) {
+      error.value = '데이터를 불러오는 중 오류가 발생했습니다.';
+    } finally {
+      isLoading.value = false;
+    }
+  });
+
+  watch(recipeData, (newData) => {
+    if (newData) {
+      // 영양 정보 데이터 가공
+      nutrition.value = {
+        calories: parseFloat(newData.INFO_ENG || '0'),
+        sodium: parseFloat(newData.INFO_NA || '0'),
+        carbohydrates: parseFloat(newData.INFO_CAR || '0'),
+        protein: parseFloat(newData.INFO_PRO || '0'),
+        fat: parseFloat(newData.INFO_FAT || '0'),
+      };
+
+      // manuals도 함께 계산
+      manuals.value = Object.entries(newData)
+        .filter(
+          ([key, value]) =>
+            key.startsWith('MANUAL') && !key.startsWith('MANUAL_IMG') && value.trim() !== '',
+        )
+        .map(([_, value]) => value)
+        .sort((a, b) => Number(a[0].split('.')[0]) - Number(b[0].split('.')[0]));
+    }
+  });
 </script>
 
 <template>
@@ -93,12 +92,12 @@
         <BookmarkButton :is-bookmarked="isBookmarked" @toggle="toggleBookmark" />
         <ShareButton />
       </div>
-      <div class="flex flex-col gap-[80px] border-mono-200 w-[1330px]">
+      <div v-if="recipeData" class="flex flex-col gap-[80px] border-mono-200 w-[1330px]">
         <!-- 상세 내용 -->
         <div class="h-[580px] flex gap-[48px] rounded-[20px] shadow-lg overflow-hidden">
           <div class="w-[677px] overflow-hidden shrink-0">
             <img
-              :src="recipeData.ATT_FILE_NO_MAIN"
+              :src="recipeData?.ATT_FILE_NO_MAIN"
               alt="recipe_image"
               class="w-full h-full object-cover object-center"
             />
@@ -106,16 +105,17 @@
           <div class="flex flex-col gap-[48px] p-[48px]">
             <div class="flex flex-col gap-4">
               <div class="text-[40px] text-main-400 font-semibold">
-                {{ recipeData.RCP_NM }}
+                {{ recipeData?.RCP_NM }}
               </div>
               <div class="text-[18px] text-mono-600">
-                {{ recipeData.RCP_PAT2 }} | {{ recipeData.RCP_WAY2 }} | #{{ recipeData.HASH_TAG }}
+                {{ recipeData?.RCP_PAT2 }} | {{ recipeData?.RCP_WAY2 }}
+                {{ recipeData.HASH_TAG ? ` | #${recipeData?.HASH_TAG}` : '' }}
               </div>
             </div>
             <div class="flex flex-col gap-4">
               <div class="text-[28px] text-main-700 font-bold">재료</div>
               <div class="text-[18px] text-mono-600">
-                {{ recipeData.RCP_PARTS_DTLS }}
+                {{ recipeData?.RCP_PARTS_DTLS }}
               </div>
             </div>
           </div>

--- a/src/views/RecipeDetailView.vue
+++ b/src/views/RecipeDetailView.vue
@@ -7,6 +7,7 @@
   import {useRoute} from 'vue-router';
   import {fetchRecipe} from '@/apis/recipeApi';
   import type {Recipe} from '@/types/RecipeResponse';
+  import {fetchYoutube} from '@/apis/youtubeApi';
 
   interface Nutrition {
     calories: number;
@@ -27,6 +28,7 @@
     fat: 0,
   });
   const manuals = ref<string[]>([]);
+  const videoId = ref<string[]>([]);
   const isLoading = ref(false);
   const error = ref<string | null>(null);
 
@@ -41,8 +43,13 @@
     // api 호출
     try {
       isLoading.value = true;
+      // 레시피 데이터 불러오기
       const data = await fetchRecipe(String(paramId.value));
       recipeData.value = data;
+      // 유튜브 데이터 불러오기
+      const keyword = String(paramId.value).split(' ').at(-1)!;
+      const youtubeResponse = await fetchYoutube(keyword);
+      videoId.value = youtubeResponse.items.map((item) => item.id.videoId);
     } catch (err) {
       error.value = '데이터를 불러오는 중 오류가 발생했습니다.';
     } finally {
@@ -159,8 +166,12 @@
         <div class="flex flex-col gap-2">
           <div class="text-[40px] text-mono-700 font-semibold">연관 레시피</div>
           <div class="flex gap-[24px]">
-            <div class="bg-mono-200 h-[360px] w-full rounded-2xl"></div>
-            <div class="bg-mono-200 h-[360px] w-full rounded-2xl"></div>
+            <div class="bg-mono-200 h-[360px] w-full rounded-2xl overflow-hidden">
+              <iframe :src="`https://www.youtube.com/embed/${videoId[0]}`" class="w-full h-full" />
+            </div>
+            <div class="bg-mono-200 h-[360px] w-full rounded-2xl overflow-hidden">
+              <iframe :src="`https://www.youtube.com/embed/${videoId[1]}`" class="w-full h-full" />
+            </div>
           </div>
         </div>
       </div>

--- a/src/views/RecipeDetailView.vue
+++ b/src/views/RecipeDetailView.vue
@@ -47,7 +47,7 @@
       const data = await fetchRecipe(String(paramId.value));
       recipeData.value = data;
       // 유튜브 데이터 불러오기
-      const keyword = String(paramId.value).split(' ').at(-1)!;
+      const keyword = String(paramId.value).replace(/\s/g, '')!;
       const youtubeResponse = await fetchYoutube(keyword);
       videoId.value = youtubeResponse.items.map((item) => item.id.videoId);
     } catch (err) {
@@ -90,6 +90,7 @@
       :breadcrumbs="[
         {title: '홈', href: '/'},
         {title: '레시피', href: '/recipe'},
+        {title: '레시피 검색', href: '/recipe/search'},
         {title: '레시피 상세'},
       ]"
     />

--- a/src/views/RecipeSearchView.vue
+++ b/src/views/RecipeSearchView.vue
@@ -76,6 +76,7 @@
         },
       });
     }
+    window.scrollTo({top: 0, behavior: 'instant'});
   };
 
   // url query 변경 및 api 호출

--- a/src/views/RecipeSearchView.vue
+++ b/src/views/RecipeSearchView.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  import {fetchRecipes} from '@/apis/recipeApi';
+  import {fetchRecipeList} from '@/apis/recipeApi';
   import BannerComponent from '@/components/BannerComponent.vue';
   import CategoryFilterButton from '@/components/recipe/CategoryFilterButton.vue';
   import RecipeRectangleCard from '@/components/recipe/RecipeRectangleCard.vue';
@@ -112,7 +112,7 @@
       // api 호출
       try {
         isLoading.value = true;
-        const data = await fetchRecipes({
+        const data = await fetchRecipeList({
           page: page.value,
           RCP_NM: searchKeyword.value,
           RCP_PAT2: searchCategory.value,
@@ -210,7 +210,12 @@
             width="516"
             :rounded="10"
           />
-          <RecipeRectangleCard v-else :title="item.RCP_NM" :image="item.ATT_FILE_NO_MAIN" />
+          <RecipeRectangleCard
+            v-else
+            :title="item.RCP_NM"
+            :image="item.ATT_FILE_NO_MAIN"
+            @click="() => router.push({name: 'recipe-detail', params: {id: item.RCP_NM}})"
+          />
         </template>
       </div>
       <v-pagination

--- a/src/views/RecipeView.vue
+++ b/src/views/RecipeView.vue
@@ -4,8 +4,7 @@
   import RecipeRectangleCard from '@/components/recipe/RecipeRectangleCard.vue';
   import RecipeSquareCard from '@/components/recipe/RecipeSquareCard.vue';
   import SearchBarRounded from '@/components/recipe/SearchBarRounded.vue';
-
-  const handleSearch = (searchText: string) => alert(`검색어: ${searchText}`);
+  import {useRouter} from 'vue-router';
 
   const recipeCategoryData = [
     {
@@ -33,18 +32,22 @@
     {
       category: '육류',
       image: '/recipe/recipe_ingredient_meat.webp',
+      ingredient: '고기',
     },
     {
       category: '채소',
       image: '/recipe/recipe_ingredient_vegetable.webp',
+      ingredient: '양파',
     },
     {
       category: '해산물',
       image: '/recipe/recipe_ingredient_seafood.webp',
+      ingredient: '새우',
     },
     {
       category: '과일',
       image: '/recipe/recipe_ingredient_fruit.webp',
+      ingredient: '사과',
     },
   ];
   const todaysRecipeData = {
@@ -93,6 +96,11 @@
       image: '/recipe/recipe_category_one_dish.webp',
     },
   ];
+
+  const router = useRouter();
+
+  const handleSearch = (searchText: string) =>
+    router.push({name: 'recipe-search', query: {keyword: searchText}});
 </script>
 
 <template>
@@ -125,6 +133,7 @@
             :image="item.image"
             :size="300"
             class="px-6 py-4"
+            @click="() => router.push({name: 'recipe-search', query: {category: item.category}})"
           />
         </template>
       </div>
@@ -150,9 +159,9 @@
           class="px-9 py-8"
         />
         <div class="flex flex-col w-[1040px] justify-between text-mono-700">
-          <div class="flex flex-col gap-4">
+          <div class="flex flex-col gap-3">
             <div class="text-[32px] font-bold">레시피 설명</div>
-            <p class="text-[20px] leading-[24px]">{{ todaysRecipeData.description }}</p>
+            <p class="text-[20px] leading-[28px]">{{ todaysRecipeData.description }}</p>
           </div>
           <div class="flex flex-col gap-2">
             <div class="text-[32px] font-bold">영양정보</div>
@@ -177,7 +186,18 @@
       <div class="ft-point text-[48px] text-mono-700">냉장고 속 재료별 레시피</div>
       <div class="flex justify-between">
         <template v-for="item in recipeIngredientData" :key="item.category">
-          <RecipeSquareCard :title="item.category" :image="item.image" :size="380" />
+          <RecipeSquareCard
+            :title="item.category"
+            :image="item.image"
+            :size="380"
+            @click="
+              () =>
+                router.push({
+                  name: 'recipe-search',
+                  query: {ingredients: item.ingredient},
+                })
+            "
+          />
         </template>
       </div>
     </div>
@@ -197,7 +217,8 @@
     </div>
     <!-- 커뮤니티 이동 배너 -->
     <div
-      class="container h-[230px] w-full bg-main-50 rounded-[12px] p-[72px] flex items-center justify-between"
+      class="container h-[230px] w-full bg-main-50 rounded-[12px] p-[72px] flex items-center justify-between cursor-pointer"
+      @click="() => router.push('/community/recipe')"
     >
       <div class="w-[200px] h-[160px] bg-[url(/recipe/recipe_illustration.svg)]"></div>
       <div class="flex flex-col items-end">

--- a/src/views/RecipeView.vue
+++ b/src/views/RecipeView.vue
@@ -120,7 +120,12 @@
       <div class="ft-point text-[48px] text-mono-700">카테고리별 레시피</div>
       <div class="flex justify-between">
         <template v-for="item in recipeCategoryData" :key="item.category">
-          <RecipeSquareCard :title="item.category" :image="item.image" :size="300" />
+          <RecipeSquareCard
+            :title="item.category"
+            :image="item.image"
+            :size="300"
+            class="px-6 py-4"
+          />
         </template>
       </div>
     </div>
@@ -142,6 +147,7 @@
           :subtitle="todaysRecipeData.subtitle"
           :image="todaysRecipeData.image"
           :size="460"
+          class="px-9 py-8"
         />
         <div class="flex flex-col w-[1040px] justify-between text-mono-700">
           <div class="flex flex-col gap-4">

--- a/src/views/RecipeView.vue
+++ b/src/views/RecipeView.vue
@@ -57,11 +57,11 @@
       '소고기 들깨 알토란탕은 고소한 들깨가루와 부드러운 소고기, 그리고 특유의 식감이 일품인 알토란을 주재료로 한 영양가 높은 한식 탕입니다. 알토란의 아삭한 식감과 들깨의 고소함이 어우러져 깊은 맛을 내며, 소고기의 감칠맛이 국물에 배어 풍미를 더합니다.',
     image: '/recipe/recipe_todays.webp',
     nutrition: {
-      INFO_ENG: 146.42,
-      INFO_NA: 675.68,
-      INFO_PRO: 7.57,
-      INFO_FAT: 5.17,
-      INFO_CAR: 17.4,
+      calories: 146.42,
+      sodium: 675.68,
+      protein: 7.57,
+      fat: 5.17,
+      carbohydrates: 17.4,
     },
   };
   const popularRecipeData = [
@@ -111,7 +111,7 @@
         <div class="flex flex-col gap-10 justify-center">
           <!-- 타이틀 -->
           <div>
-            <div class="text-[40px] text-mono-050 leading-10">혼자 살아도 건강하게!</div>
+            <div class="text-[40px] text-mono-050 leading-[52px]">혼자 살아도 건강하게!</div>
             <div class="text-[48px] font-bold text-mono-050 leading-16">
               자취생을 위한 영양만점 레시피
             </div>
@@ -143,7 +143,11 @@
       <div class="ft-point text-[48px] text-mono-700">인기 레시피</div>
       <div class="flex justify-between">
         <template v-for="item in popularRecipeData" :key="item.title">
-          <RecipeRectangleCard :image="item.image" :title="item.title" />
+          <RecipeRectangleCard
+            :image="item.image"
+            :title="item.title"
+            @click="router.push({name: 'recipe-detail', params: {id: item.title}})"
+          />
         </template>
       </div>
     </div>
@@ -157,6 +161,13 @@
           :image="todaysRecipeData.image"
           :size="460"
           class="px-9 py-8"
+          @click="
+            () =>
+              router.push({
+                name: 'recipe-detail',
+                params: {id: todaysRecipeData.title},
+              })
+          "
         />
         <div class="flex flex-col w-[1040px] justify-between text-mono-700">
           <div class="flex flex-col gap-3">


### PR DESCRIPTION
- 레시피 메인에서 리얼 자취생 레시피 섹션 제외하고 기능 구현 했습니다
- 레시피 상세에서 레시피 이름으로 데이터 불러와서 뿌려주었고, youtube api 사용하여 연관 레시피 섹션 구현했습니다.
![screencapture-localhost-5173-recipe-detail-2025-03-06-09_51_58](https://github.com/user-attachments/assets/67d5899d-18a1-410e-ab78-604b52de71ff)
